### PR TITLE
Solve rubygems deprecation in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rails', '~> 3.0.20'
 


### PR DESCRIPTION
`source :rubygems` has been deprecated in favor of explicitly specifying the URL: `https://rubygems.org`
