### PR TITLE
Fix editing and displaying comments on page

### DIFF
--- a/app/permissions/posts_permission.rb
+++ b/app/permissions/posts_permission.rb
@@ -12,7 +12,7 @@ module PostsPermission
 
   def may_edit_post?(post=@post)
     logged_in? and
-    (may_message? || @page) and
+    (@page || may_message?) and
     post and
     post.user_id == current_user.id
   end

--- a/test/functional/pages/posts_controller_test.rb
+++ b/test/functional/pages/posts_controller_test.rb
@@ -1,0 +1,33 @@
+require_relative '../../test_helper'
+
+class Pages::PostsControllerTest < ActionController::TestCase
+
+  def setup
+    @user = FactoryGirl.create :user
+    @page = FactoryGirl.create(:page, :owner => @user)
+  end
+
+  def teardown
+    @user.destroy if @user
+    @page.destroy if @page
+  end
+
+  def test_create_post
+    login_as @user
+    body = "Test Message"
+    xhr :post, :create, page_id: @page.id, post: {
+      body: body
+    }
+    assert_response :success
+    assert_equal 1, @page.reload.posts.count
+    assert_equal body, @page.posts.first.body
+  end
+
+  def test_edit_post
+    @post = Post.create! @page, @user, {body: "Test Contetn"}
+    login_as @user
+    xhr :get, :edit, page_id: @page.id, id: @post.id
+    assert_response :success
+    assert_equal @post, assigns[:post]
+  end
+end


### PR DESCRIPTION
may_message? was getting called even in a page context.

We now prevent this by testing @page || may_message? instead of the other way round.
