### PR TITLE
only paginate if posts respond_to :total_pages

### DIFF
--- a/app/helpers/common/page/post_helper.rb
+++ b/app/helpers/common/page/post_helper.rb
@@ -6,7 +6,7 @@ module Common::Page::PostHelper
   # klass should be 'first' or 'last'
   #
   def post_pagination_links(posts, klass)
-    if posts.any?
+    if posts.any? && posts.respond_to?(:total_pages)
       if @page
         param_name = 'posts'
       else


### PR DESCRIPTION
We use the same helper to render posts in different places.

Some of them paginate some others don't. The latter do not have
the necessary data incl. total_pages. So if we try to paginate
them it will crash.

We used to check for the class of posts. But since will_paginates
changed this is now always a relation. It's also recommended
to test responds_to? instead of class.
