### PR TITLE
fix dispatch controller test, add user not found test

### DIFF
--- a/test/functional/dispatch_controller_test.rb
+++ b/test/functional/dispatch_controller_test.rb
@@ -2,13 +2,12 @@ require_relative '../test_helper'
 
 class DispatchControllerTest < ActionController::TestCase
 
-  def test_non_existent_context
+  def test_process_raises_not_found
     assert_raises ErrorNotFound do
       get :dispatch, _context: 'pretty-sure-this-context-does-not-exist'
     end
     assert_nil assigns[:user]
     assert_nil assigns[:group]
-    assert_response 404
   end
 
 end

--- a/test/functional/people/home_controller_test.rb
+++ b/test/functional/people/home_controller_test.rb
@@ -13,10 +13,14 @@ class People::HomeControllerTest < ActionController::TestCase
     user = FactoryGirl.create :user
     login_as :blue
     get :show, :person_id => user.login
-    assert_response 404
-    assert_nil assigns[:user]
-    assert_nil assigns[:group]
+    assert_no_user_found
     user.destroy
+  end
+
+  def test_missing_user
+    login_as :blue
+    get :show, :person_id => "missinguserlogin"
+    assert_no_user_found
   end
 
   def test_new_user_visible_to_friends
@@ -27,5 +31,13 @@ class People::HomeControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal user, assigns[:user]
     user.destroy
+  end
+
+  # there should be no difference between a hidden user
+  # and a user not found...
+  def assert_no_user_found
+    assert_response 404
+    assert_nil assigns[:user]
+    assert_nil assigns[:group]
   end
 end


### PR DESCRIPTION
I want to ensure the response to a non existing context is the same as the
one to a hidden one. However this is not easy when functional testing the
dispatch controller. ActionController::TestCase will call process directly
instead of dispatch. So no way of testing the specific behaviour of
the dispatch controller.

Instead i now test the people/home controller with a hidden user and a
wrong username.

Integration and unit testing probably is the way to go for the dispatch controller.
