### PR TITLE
Hacky fix to not throw error for memberships that don't have a created_a...

### DIFF
--- a/app/models/user_extension/groups.rb
+++ b/app/models/user_extension/groups.rb
@@ -154,7 +154,8 @@ module UserExtension::Groups
     if group.created_at > 1.week.ago
       member_of?(group)
     elsif membership = group.memberships.find_by_user_id(self.id)
-      membership.created_at < 1.week.ago
+      # hacky fix to catch old memberships that don't have a created_at:
+      (membership.created_at || 2.weeks.ago) < 1.week.ago
     end
   end
 


### PR DESCRIPTION
...t. This should not happen, but there are some very old memberships that do not have a created_at.
