### PR TITLE
Ensure users can always see themselves

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -282,6 +282,8 @@ class User < ActiveRecord::Base
   def may!(perm, protected_thing)
     return false if protected_thing.nil?
     return true if protected_thing.new_record?
+    # users may perform all actions on themselves
+    return true if self == protected_thing
     key = "#{protected_thing.to_s}"
     if @access and @access[key] and !@access[key][perm].nil?
       result = @access[key][perm]

--- a/test/functional/people/home_controller_test.rb
+++ b/test/functional/people/home_controller_test.rb
@@ -9,6 +9,16 @@ class People::HomeControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_show
+    login_as :blue
+    blue = users(:blue)
+    blue.revoke_access! CastleGates::Holder[blue.associated(:friends)] => :view
+    blue.revoke_access! CastleGates::Holder[blue.associated(:peers)] => :view
+    blue.revoke_access! :public => :view
+    get :show, :person_id => 'blue'
+    assert_response :success
+  end
+
   def test_new_user_hidden
     user = FactoryGirl.create :user
     login_as :blue


### PR DESCRIPTION
A user should be allowed to perform all actions on themselves. If they do not make sense (friending, sending messages) we prevent this on the permissions level.

Including a functional test
