### PR TITLE
reset User.current after logging out.

### DIFF
--- a/test/helpers/integration/account_management.rb
+++ b/test/helpers/integration/account_management.rb
@@ -41,6 +41,7 @@ module AccountManagement
     @user = current_user
     login unless @user.is_a? UnauthenticatedUser
     block.arity == 1 ? yield(@user) : yield
+  ensure
     Capybara.reset_sessions!
     User.current = nil
   end


### PR DESCRIPTION
Otherwise that user will be used as an initial member whenever new groups are created.
