### PR TITLE
work around CVE-2013-4491 i18n xss issue

### DIFF
--- a/config/initializers/i18n-security.rb
+++ b/config/initializers/i18n-security.rb
@@ -1,0 +1,26 @@
+# Work around CVE-2013-4491
+# taken from https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998
+#
+
+require 'i18n'
+
+# Override exception handler to more carefully html-escape missing-key results.
+class HtmlSafeI18nExceptionHandler
+  Missing = I18n.const_defined?(:MissingTranslation) ? I18n::MissingTranslation : I18n::MissingTranslationData
+
+  def initialize(original_exception_handler)
+    @original_exception_handler = original_exception_handler
+  end
+
+  def call(exception, locale, key, options)
+    if exception.is_a?(Missing) && options[:rescue_format] == :html
+      keys = exception.keys.map { |k| Rack::Utils.escape_html k }
+      key = keys.last.to_s.gsub('_', ' ').gsub(/\b('?[a-z])/) { $1.capitalize }
+      %(<span class="translation_missing" title="translation missing: #{keys.join('.')}">#{key}</span>)
+    else
+      @original_exception_handler.call(exception, locale, key, options)
+    end
+  end
+end
+
+I18n.exception_handler = HtmlSafeI18nExceptionHandler.new(I18n.exception_handler)


### PR DESCRIPTION
see https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998

There is a vulnerability in the internationalization component of Ruby on Rails. Under certain common configurations an attacker can provide specially crafted input which will execute a reflective XSS attack.  This vulnerability has been assigned the CVE identifier CVE-2013-4491.

Versions Affected:  3.0.6 and all later versions.
Not affected:       3.0.5 and earlier 3.0.x versions.
Fixed Versions:     4.0.2, 3.2.16.

The root cause of this issue is a vulnerability in the i18n gem which has been assigned the identifier CVE-2013-4492. For this reason applications are also not affected if they have upgraded to the following i18n versions:
- i18n-0.6.6 for Rails 4.0.x and 3.2.x applications
- i18n-0.5.1 for Rails 3.1.x and 3.0.x applications
## Impact

When the i18n gem is unable to provide a translation for a given string, it creates a fallback HTML string.  Under certain common configurations this string can contain user input which would allow an attacker to execute a reflective XSS attack.

All users running an affected release should either upgrade or use one of the workarounds immediately.
## Releases

The 4.0.2 and 3.2.16 releases are available at the normal locations.
## Workarounds

To work around this issue you must replace the standard i18n exception handler with a fixed one.  Place the following code into a file in the config/initializers directory of your project and restart the server.

This is the workaround we added.

i18n 0.5.1 seems to have been revoked.
i18n ~> 0.5.2 breaks rails translate method
