### PR TITLE
While it wouldn't get displayed anyway, should not by default create a n...

### DIFF
--- a/app/models/discussion/discussion.rb
+++ b/app/models/discussion/discussion.rb
@@ -144,7 +144,7 @@ class Discussion < ActiveRecord::Base
       :last_post => post,
       :replied_by_id => post.user_id,
       :replied_at => post.updated_at )
-    PrivateMessageNotice.create!(:user => post.discussion.user_talking_to(post.user), :message => post.body_html, :from => post.user)
+    PrivateMessageNotice.create!(:user => post.discussion.user_talking_to(post.user), :message => post.body_html, :from => post.user) if post.private?
 
   end
 


### PR DESCRIPTION
...otice for message posts unless they are private.
