### PR TITLE
fix translation interpolation - fixes #7814

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -498,7 +498,7 @@ de:
   member_groups_of_network: "Gruppen im Netzwerk"
   members: BenutzerInnen
   membership: Mitgliedschaft
-  membership_destroy_confirm_message: "Bist du sicher das du '%{user}' von %{group_type} entfernen willst?"
+  membership_destroy_confirm_message: "Bist du sicher das du '%{entity}' aus %{group} entfernen willst?"
   membership_exists_error: "Mitgliedschaft besteht bereits für %{member}"
   membership_leave_message: "Du wurdest von %{group} entfernt"
   menu_admin: Admin

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -499,7 +499,7 @@ es:
   member_groups_of_network: "Grupos Miembros"
   members: Personas
   membership: Afiliaciones
-  membership_destroy_confirm_message: "¿Tienes la certeza de que quieres retirar a '%{user}' de %{group_type}?"
+  membership_destroy_confirm_message: "¿Tienes la certeza de que quieres retirar a '%{entity}' de %{group}?"
   membership_exists_error: "Ya %{member} tiene una afiliación"
   membership_leave_message: "Te han retirado de %{group}"
   menu_admin: Admin

--- a/test/functional/groups/memberships_controller_test.rb
+++ b/test/functional/groups/memberships_controller_test.rb
@@ -1,6 +1,7 @@
-require File.dirname(__FILE__) + '/../../test_helper'
+require 'test_helper'
 
 class Groups::MembershipsControllerTest < ActionController::TestCase
+  fixtures :all
 
   def setup
     @user  = FactoryGirl.create(:user)
@@ -30,4 +31,10 @@ class Groups::MembershipsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_index_with_links_to_destroy
+    login_as users(:blue)
+    get :index, { group_id: groups(:warm) },
+      { language_code: 'de' }
+    assert_response :success
+  end
 end


### PR DESCRIPTION
membership_destroy_confirm_message was expecting :entity and :group but still got :user and :group_type in spanish and german locales
