### PR TITLE
do not cache action_symbol - fixes #7815

### DIFF
--- a/app/controllers/common/application/url_identifiers.rb
+++ b/app/controllers/common/application/url_identifiers.rb
@@ -153,7 +153,7 @@ module Common::Application::UrlIdentifiers
   end
 
   def action_symbol
-    @action_symbol ||= if params[:action].present?
+    if params[:action].present?
       params[:action].to_sym
     else
       nil

--- a/extensions/pages/wiki_page/test/integration/wiki_test.rb
+++ b/extensions/pages/wiki_page/test/integration/wiki_test.rb
@@ -12,7 +12,7 @@ class WikiTest < JavascriptIntegrationTest
   end
 
   def test_writing_initial_version
-    # assert_page_tab "Edit"
+    assert_page_tab "Edit"
     content = update_wiki
     assert_content content
     assert_page_tab "Show"


### PR DESCRIPTION
we change the action param for wikis if it's fresh. So if we cache the symbol
we end up with inconsistent action_symbol and action_string. We also end up
with the show tab being active despite edit being rendered.
