### PR TITLE
no cache for Page#show - load ajaxy changes - fixes #7849

### DIFF
--- a/app/controllers/pages/base_controller.rb
+++ b/app/controllers/pages/base_controller.rb
@@ -8,6 +8,7 @@ class Pages::BaseController < ApplicationController
 
   before_filter :login_required, except: :show
   before_filter :authorization_required
+  before_filter :bust_cache, only: :show
   permissions :pages
   guard :may_ACTION_page?
   guard print: :may_show_page?

--- a/app/controllers/pages/before_filters.rb
+++ b/app/controllers/pages/before_filters.rb
@@ -74,6 +74,16 @@ module Pages::BeforeFilters
     end
   end
 
+  # ensure the page will be reloaded when navigated to in browser history
+  # why? because we use a bunch of ajax on the pages - for example when
+  # adding comments. It's really odd if these disappear when you navigate
+  # back.
+  def bust_cache
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
+
   ##
   ## AFTER FILTERS
   ##


### PR DESCRIPTION
ensure the page will be reloaded when navigated to in browser history
why? because we use a bunch of ajax on the pages - for example when
adding comments. It's really odd if these disappear when you navigate
back.
