### PR TITLE
i18n: remove audio related keys from gallery

### DIFF
--- a/config/locales/en/gallery.yml
+++ b/config/locales/en/gallery.yml
@@ -59,9 +59,4 @@ en:
   edit_image_header: "Edit Image and Audio"
   upload_images_and_zip_files_help: "Optional: Select image or zip files to upload."
   close_and_reload_gallery: 'Close and reload gallery'
-  audio_updated: 'Updated the audio'
-  audio_selected: 'Selected audio for the image'
-  audio_updated_successfully: 'The audio for this image has been updated successfully.'
-  audio_selected_successfully:  'You picked a new audio track to go with this image.'
-  audio_attached: 'This image has an audio caption below, loading might take some time.'
   


### PR DESCRIPTION
we removed the audio feature for galleries in the core rework.