### PR TITLE
performance: tweaks for user permission migration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,10 @@ class User < ActiveRecord::Base
   ##
 
   has_many :profiles, as: 'entity', dependent: :destroy, extend: ProfileMethods
+  has_one :public_profile, as: 'entity', class_name: 'Profile',
+    conditions: {stranger: true}
+  has_one :private_profile, as: 'entity', class_name: 'Profile',
+    conditions: {friend: true}
 
   def profile(reload=false)
     @profile = nil if reload
@@ -335,21 +339,24 @@ class User < ActiveRecord::Base
   # Migrate permissions from pre-CastleGates databases to CastleGates.
   # Called from cg:upgrade:user_permissions task.
   def migrate_permissions!
+    private_gates = []
+    public_gates = []
     # get holders
     print '.' if id % 10 == 0
-    public_holder = CastleGates::Holder[:public]
-    friends_holder = CastleGates::Holder[associated(:friends)]
-    peers_holder = CastleGates::Holder[associated(:peers)]
 
-    public_gates  = profiles.public.to_gates
-    private_gates = profiles.private.to_gates
-    friends_gates = (private_gates + public_gates).uniq
-    set_access! public_holder => public_gates
-    set_access! friends_holder => friends_gates
-    if profiles.private.peer?
-      set_access! peers_holder => friends_gates
-    else
-      set_access! peers_holder => public_gates
+    if public_profile
+      public_gates = public_profile.to_user_gates
+      set_access! public: public_gates
+    end
+    if private_profile
+      private_gates = private_profile.to_user_gates
+      friends_gates = (private_gates + public_gates).uniq
+      set_access! friends: friends_gates
+      if private_profile.peer?
+        set_access! peers: friends_gates
+      elsif public_gates.present?
+        set_access! peers: public_gates
+      end
     end
   end
 

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -39,12 +39,12 @@ namespace :cg do
 
     desc "Create keys to the groups based on their old profile settings; for use once in upgrading data to cg 1.0"
     task(:migrate_group_permissions => :environment) do
-      Group.all.each(&:migrate_permissions!)
+      Group.includes(:keys, :public_profile).find_each(&:migrate_permissions!)
     end
 
     desc "Creates keys to the user based on settings found in their old profile; also for use once upgrading data to cg 1.0"
     task :user_permissions => :environment do
-      User.all.each(&:migrate_permissions!)
+      User.includes(:keys, :public_profile, :private_profile).find_each(&:migrate_permissions!)
     end
 
     desc "Set created_at timestamps where it is not set"

--- a/vendor/crabgrass_plugins/castle_gates/lib/castle_gates/castle/associations.rb
+++ b/vendor/crabgrass_plugins/castle_gates/lib/castle_gates/castle/associations.rb
@@ -67,7 +67,13 @@ def self.included(base)
       #
       def find_by_holder(holder)
         holder = Holder[holder, self]
-        find_or_initialize_by_holder_code(holder.code)
+        code = holder.code
+        # let's use preloaded keys if possible
+        if loaded?
+          key = detect{|k| k.holder_code = code}
+          return key if key
+        end
+        where(holder_code: code).first_or_initialize
       end
 
       def select_holder_codes

--- a/vendor/crabgrass_plugins/castle_gates/lib/castle_gates/key.rb
+++ b/vendor/crabgrass_plugins/castle_gates/lib/castle_gates/key.rb
@@ -112,14 +112,7 @@ module CastleGates
     # Returns the bitmask for a set of gate names.
     #
     def bits_for_gates(gate_names)
-      if castle
-        # there are edge cases where castle might be nil.
-        # for example, if it was destroyed in db but grant_access
-        # was called on older in-memory copy.
-        castle.gate_set.bits(gate_names)
-      else
-        0
-      end
+      castle_type.constantize.gate_set.bits(gate_names)
     end
 
   end


### PR DESCRIPTION
Instead of fetching the castle for a key and then looking at its class for the gate_set we now constantize the castle_type.

When the keys of a castle are loaded we now detect the one with the appropriate holder_code instead of fetching it from the database.

We also allow for preloading public and private_profile