### PR TITLE
bugfix: avatars always use a single resource

### DIFF
--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -17,6 +17,12 @@
 require 'open-uri'
 
 class Avatar < ActiveRecord::Base
+  
+  # This is only used in singular resources and avatar_path.
+  # So we use this workaround for form_for paths:
+  # https://github.com/rails/rails/issues/1769#issuecomment-41025758
+  model_name.instance_variable_set(:@route_key, 'avatar')
+
 
   DEFAULT_DIR = "#{Rails.root}/public/images/default"
 

--- a/test/integration/group_settings_test.rb
+++ b/test/integration/group_settings_test.rb
@@ -1,0 +1,22 @@
+require 'javascript_integration_test'
+
+class GroupSettingsTest < JavascriptIntegrationTest
+
+  def setup
+    super
+    @user = users(:blue)
+    login
+  end
+
+  def test_editing_profile
+    visit '/animals'
+    click_on 'Settings'
+    assert_selector 'img.avatar[src="/avatars/0/large.jpg?0"]'
+    click_on 'upload image'
+    attach_file 'avatar_image_file', fixture_file('photo.jpg')
+    click_on 'Upload Image'
+    assert_no_selector 'img.avatar[src="/avatars/0/large.jpg?0"]'
+    assert_selector 'img.avatar[src*="/avatars/"][src*="large.jpg"]'
+  end
+
+end


### PR DESCRIPTION
So we set this in the model to work around the plural default.
This is because of a loong pending rails bug:
https://github.com/rails/rails/issues/1769