### PR TITLE
Fix wiki asset upload form markup

### DIFF
--- a/app/controllers/wikis/base_controller.rb
+++ b/app/controllers/wikis/base_controller.rb
@@ -15,7 +15,7 @@ class Wikis::BaseController < ApplicationController
   def fetch_wiki
     @wiki = Wiki.find(params[:wiki_id] || params[:id])
     @page = @wiki.page
-    if params[:section]
+    if params[:section].present?
       @section = params[:section]
       @body = @wiki.get_body_for_section(@section)
     else

--- a/app/helpers/common/ui/form_helper.rb
+++ b/app/helpers/common/ui/form_helper.rb
@@ -50,25 +50,23 @@ module Common::Ui::FormHelper
   end
 
   #
-  # add some radio buttons, using a similar api to select and select_tag
+  # add a row of radio buttons with labels
+  # using a similar api to select and select_tag
   #
   # choices: array of choices in the form [[label, id],[label, id]]
   #
   # options:
-  #  * :separator - will be used to separate the buttons
-  #  * :selected - id of the selected button
-  #  ... all others will be handed over to the radio_button_tag.
+  #  * :selected  - id of the selected option(s)
+  #   all others will be handed over to the radio_button_tag.
   #
-  def radio_buttons_tag(name, choices, options={})
-    join = options.delete(:separator) || ' '
-    selected = options.delete(:selected) || choices.first[1]
-    html = []
-    choices.each do |label, id|
-      checked = selected == id
-      html << radio_button_tag(name, id, checked, options) +
-              label_tag("%s_%s" % [name, id], label)
-    end
-    html.join(join)
+  def inline_radio_buttons(name, choices, options = {})
+    render partial: 'ui/form/inline_radio_button', 
+      collection: choices,
+      locals: {
+        name: name, 
+        selected: options.delete(:selected) || choices.first[1],
+        options: options
+      }
   end
 
   #

--- a/app/helpers/wikis/assets_helper.rb
+++ b/app/helpers/wikis/assets_helper.rb
@@ -2,10 +2,8 @@ module Wikis::AssetsHelper
 
   def image_size_buttons
     sizes = [:small, :medium, :large, :full]
-    translated_sizes = sizes.map do |s|
-      [s.t, s.to_s]
-    end
-    radio_buttons_tag 'image_size', translated_sizes,
+    translated_sizes = sizes.map{|size| [size.t, size.to_s]}
+    inline_radio_buttons 'image_size', translated_sizes,
       id: 'image_size',
       selected: 'medium',
       onchange: "updatePreview();"

--- a/app/views/ui/form/_inline_radio_button.html.haml
+++ b/app/views/ui/form/_inline_radio_button.html.haml
@@ -1,0 +1,5 @@
+- label, id = inline_radio_button
+- checked = selected == id
+%label.radio.inline
+  = radio_button_tag name, id, checked, options
+  = label

--- a/app/views/wikis/assets/_select_buttons.html.haml
+++ b/app/views/wikis/assets/_select_buttons.html.haml
@@ -1,6 +1,6 @@
 .image_select_list
   - @images.each do |image|
     = data_tag_for_image(image)
-  = radio_buttons_tag :image, image_tags_and_ids(@images), onchange: "updatePreview();"
+  = inline_radio_buttons :image, image_tags_and_ids(@images), onchange: "updatePreview();"
   .clear
     = pagination_links(@images)

--- a/app/views/wikis/wikis/edit.js.rjs
+++ b/app/views/wikis/wikis/edit.js.rjs
@@ -1,9 +1,10 @@
 template = local_assigns[:mode] || 'edit'
+section = @section.presence || :document
 
-if @section == :document
+if section == :document
   page.replace_html dom_id(@wiki), :partial => "wikis/wikis/#{template}"
 else
-  page.replace_html dom_id(@wiki, @section.underscore), :partial => "wikis/wikis/#{template}"
+  page.replace_html dom_id(@wiki, section.underscore), :partial => "wikis/wikis/#{template}"
   # don't allow multiple section edits at a time:
   page << "$$('.wiki-section-edit').invoke('hide')"
 end
@@ -11,7 +12,7 @@ end
 if template == 'edit'
   page << create_wiki_toolbar(@wiki)
   page << confirm_discarding_wiki_edit_text_area(@wiki)
-  page << release_lock_on_unload(@wiki, @section)
+  page << release_lock_on_unload(@wiki, section)
 end
 
 # hide errors, stop spinners


### PR DESCRIPTION
Turned radio_buttons_tag into inline_radio_buttons:

* use a partial rather than joining tags together by hand.
  This way no .html_safe is needed.

* wrap the radio_button in a label. This way we do not need an id for the label
  and it's the default way for doing this kind of thing with bootstrap