### PR TITLE
encode + in group names in share autocomplete

### DIFF
--- a/app/assets/javascripts/crabgrass/autocomplete.js
+++ b/app/assets/javascripts/crabgrass/autocomplete.js
@@ -25,5 +25,8 @@ function autoCompleteRowRenderer(value, re, data) {
 }
 
 function autoCompleteSelectValue(value){
-  return value.replace(/<em>(.*)<\/em>.*/g,'$1');
+  // if there are two rows pick the second one
+  row = value.replace(/.*<br\/>(.*)/g,'$1');
+  // encode text without the tags 
+  return encodeURIComponent(row.replace(/<[^>]*>/g,''));
 }

--- a/app/helpers/common/ui/entity_display_helper.rb
+++ b/app/helpers/common/ui/entity_display_helper.rb
@@ -202,7 +202,7 @@ module Common::Ui::EntityDisplayHelper
   # used when generating json to return for autocomplete popups
   #
   def entity_autocomplete_line(entity)
-    "<em>%s</em>%s" % [entity.name, ('<br/>' + h(entity.display_name) if entity.display_name != entity.name)]
+    "<em>%s</em>%s" % [entity.display_name, ('<br/>' + h(entity.name) if entity.display_name != entity.name)]
   end
 
   def entity_list(entities, options={})

--- a/app/views/pages/shares/_recipient.html.haml
+++ b/app/views/pages/shares/_recipient.html.haml
@@ -16,7 +16,6 @@
 - newitem = true if @page and @page.new_record?
 - alter_access = true if alter_access.nil?
 - 
-- recipient_name = recipient.name.gsub(/\+/,"%2b")   # encode + as %2b
 - participation = (@page.participation_for(recipient) if @page)
 - 
 - id = "share_recipient_%s" % recipient.name
@@ -31,7 +30,7 @@
       = hidden_field_tag "recipients[#{recipient.name}]", "1", id: id
       = display_access(participation)
     - elsif may_select_access_participation?
-      = select_page_access "recipients[#{recipient_name}][access]", access_options
+      = select_page_access "recipients[#{recipient.name}][access]", access_options
     - else
       -# why is this included as a hidden field if you are not allowed to set the access level?
       -# perhaps if may_select_access_participations is false, then a default should be hard coded? -elijah

--- a/test/helpers/integration/javascript/autocomplete.rb
+++ b/test/helpers/integration/javascript/autocomplete.rb
@@ -22,11 +22,12 @@ module Autocomplete
   def autocomplete(field, options)
     chars ||= 1
     # the space is a work around as the first letter may get cut off
-    fill_in field, with: ' ' + options[:with][0,chars]
+    fill_in field, with: ' '
+    fill_in field, with: options[:with][0,chars]
     # poltergeist will not keep the element focussed.
     # But when we loose focus the autocomplete won't show.
     execute_script("($('#{field}') || $$('[name=#{field}]')[0]).focus();")
-    find('.autocomplete em', text: options[:with]).trigger('click')
+    find('.autocomplete p', text: options[:with]).trigger('click')
   rescue Capybara::ElementNotFound
     chars +=1
     raise if chars > 3

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -37,6 +37,11 @@ class PageSidebarTest < JavascriptIntegrationTest
     assert_page_groups groups(:animals)
   end
 
+  def test_share_with_committee
+    share_page_with groups(:cold)
+    assert_page_groups groups(:cold)
+  end
+
   # regression test for #7834
   def test_sharing_preserves_stars
     star_page


### PR DESCRIPTION
+ is a way to encode ' '. So it will be replaced by rails automagically.
So we have to encode it when sending the first request.
In the form it will be encoded anyway. So no need to replace it in the hidden input.

While we are at it... also display the display_name on top and in bold and the name below

I may have found a way to fix the annoying non determenistic autocomplete integration
test failure at the same time. One thing is for sure ' r' in the field will trigger
the first request to autocomplete - even if the thing we are looking for is already
seeded. So instead i now try to fill in the space first - to prevent the first char
from getting cut off and then fill in only the term to autocomplete.