### PR TITLE
bugfix: do not show Home and Pages links for hidden groups

### DIFF
--- a/app/controllers/common/application/rescue_errors.rb
+++ b/app/controllers/common/application/rescue_errors.rb
@@ -109,6 +109,8 @@ module Common::Application::RescueErrors
   # by any message in the exception.
   #
   def render_not_found(exception=nil)
+    # Claim something was not found when people may not access it
+    exception = ErrorNotFound.new(:page.t) if exception.is_a? PermissionDenied
     respond_to do |format|
       format.html do
         render_not_found_html(exception)

--- a/app/controllers/groups/home_controller.rb
+++ b/app/controllers/groups/home_controller.rb
@@ -2,6 +2,8 @@ class Groups::HomeController < Groups::BaseController
 
   skip_before_filter :login_required
   guard :may_show_group?
+  rescue_from PermissionDenied, with: :render_not_found
+
   before_filter :fetch_wikis
 
   layout 'sidecolumn'

--- a/app/controllers/groups/pages_controller.rb
+++ b/app/controllers/groups/pages_controller.rb
@@ -1,9 +1,10 @@
 class Groups::PagesController < Groups::BaseController
 
   skip_before_filter :login_required
-  include_controllers 'common/page_search'
-
   guard :may_show_group?
+  rescue_from PermissionDenied, with: :render_not_found
+  
+  include_controllers 'common/page_search'
 
   def index
     @path  = apply_path_modifiers( parsed_path() )

--- a/app/permissions/groups/base_permission.rb
+++ b/app/permissions/groups/base_permission.rb
@@ -7,10 +7,7 @@ module Groups::BasePermission
 
   # used from the home controller
   def may_show_group?(group = @group)
-    return true if current_user.may? :view, group
-    # let's make sure this looks like a failing dispatch
-    @group = nil
-    raise_not_found(:page.t)
+    current_user.may? :view, group
   end
 
   def may_edit_group?(group = @group)

--- a/extensions/themes/default/navigation.rb
+++ b/extensions/themes/default/navigation.rb
@@ -228,6 +228,7 @@ define_navigation do
     end
 
     context_section :home do
+      visible { may_show_group? }
       label  { :home.t }
       icon   :house
       url    { entity_path(@group) }
@@ -235,6 +236,7 @@ define_navigation do
     end
 
     context_section :pages do
+      visible { may_show_group? }
       label  { :pages.t }
       icon   :page_white_copy
       url    { group_pages_path(@group) }

--- a/test/helpers/integration/page_records.rb
+++ b/test/helpers/integration/page_records.rb
@@ -7,8 +7,9 @@ module PageRecords
     save_and_index(page)
   end
 
-  def public_page
-    page = new_page public: true
+  def public_page(options = {})
+    options[:public] = true
+    page = new_page options
     save_and_index(page)
   end
 

--- a/test/integration/page_access_test.rb
+++ b/test/integration/page_access_test.rb
@@ -16,6 +16,14 @@ class PageAccessTest < JavascriptIntegrationTest
     assert_content 'Not Found'
   end
 
+  def test_public_page_of_hidden_group
+    # groups are hidden by default
+    page = public_page owner: group
+    visit_page(page)
+    assert_content page.title
+    assert_no_content 'Pages'
+  end
+
   def visit_page(page)
     visit "/pages/#{page.name_url}"
   end


### PR DESCRIPTION
You may still see the banner if a page of that group is accessible