### PR TITLE
bugfix/no-ids-in-search-paths

### DIFF
--- a/extensions/search_filters/access/group.rb
+++ b/extensions/search_filters/access/group.rb
@@ -14,7 +14,7 @@ SearchFilter.new('/group/:group_id/') do
 
   label do |opts|
     if opts[:group_id]
-      "#{:group.t}: #{group_name(opts[:group_id])}"
+      "#{:group.t}: #{opts[:group_id]}"
     else
       :group.t + '...'
     end

--- a/extensions/search_filters/access/user.rb
+++ b/extensions/search_filters/access/user.rb
@@ -14,7 +14,7 @@ SearchFilter.new('/user/:user_id/') do
 
   label do |opts|
     if opts[:user_id]
-      "#{:user.t}: #{user_login(opts[:user_id])}"
+      "#{:user.t}: #{opts[:user_id]}"
     else
       :user.t + '...'
     end

--- a/extensions/search_filters/associations/created_by.rb
+++ b/extensions/search_filters/associations/created_by.rb
@@ -16,7 +16,7 @@ SearchFilter.new('/created-by/:user_id/') do
 
   label do |opts|
     if opts[:user_id]
-      :created_by_user.t(user: user_login(opts[:user_id]).capitalize)
+      :created_by_user.t(user: opts[:user_id].capitalize)
     else
       :created_by_dotdotdot.t
     end

--- a/vendor/crabgrass_plugins/crabgrass_path_finder/lib/search_filter.rb
+++ b/vendor/crabgrass_plugins/crabgrass_path_finder/lib/search_filter.rb
@@ -154,44 +154,13 @@ class SearchFilter
   protected
 
   def user_id(id)
-    if id =~ /^\d*$/
-      id
-    else
-      user = User.find_by_login(id)
-      raise ErrorNotFound.new("#{:user.t} #{id.inspect}") unless user
-      user.id
-    end
-  end
-
-  def user_login(id)
-    if id =~ /^\d*$/
-      user = User.find_by_id(id)
-      raise ErrorNotFound.new("#{:user.t} #{id.inspect}") unless user
-      user.login
-    else
-      id.nameize # don't let invalid names through.
-                 # The user might have given us dangerious input.
-    end
+    User.where(login: id).limit(1).pluck(:id).first || 
+      raise(ErrorNotFound.new("#{:user.t} #{id.inspect}"))
   end
 
   def group_id(id)
-    if id =~ /^\d*$/
-      id
-    else
-      group = Group.find_by_name(id)
-      raise ErrorNotFound.new("#{:group.t} #{id.inspect}") unless group
-      group.id
-    end
-  end
-
-  def group_name(id)
-    if id =~ /^\d*$/
-      group = Group.find_by_id(id)
-      raise ErrorNotFound.new("#{:group.t} #{id.inspect}") unless group
-      group.name
-    else
-      id.nameize # don't let invalid names through.
-    end
+    Group.where(name: id).limit(1).pluck(:id).first ||
+      raise(ErrorNotFound.new("#{:group.t} #{id.inspect}"))
   end
 
   ##


### PR DESCRIPTION
We used to allow ids in search paths. But numbers may also be used as logins or group names.
So determining the exact group or user may not be possible.