### PR TITLE
Include preloaded results in filtered autocomplete queries

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -41,9 +41,7 @@ class EntitiesController < ApplicationController
       if preload?
         group.users
       else
-        []
-      #elsif filter.present?
-      #  group.users.named_like(filter).find(:all, :limit => LIMIT)
+        group.users.named_like(filter).limit(LIMIT)
       end
     else
       []
@@ -57,9 +55,8 @@ class EntitiesController < ApplicationController
     if preload?
       User.friends_or_peers_of(current_user).all_with_access(current_user => :pester)
     elsif filter.present?
-      recipients = User.strangers_to(current_user)
-      recipients = recipients.with_access(public: :pester)
-      recipients.named_like(filter).find(:all, limit: LIMIT)
+      recipients = User.with_access(current_user => :pester)
+      recipients.named_like(filter).limit(LIMIT)
     end
   end
 
@@ -70,9 +67,8 @@ class EntitiesController < ApplicationController
     if preload?
       current_user.all_groups
     elsif filter.present?
-      other_groups = Group.without_member(current_user)
-      other_groups = other_groups.with_access(public: :view)
-      other_groups.named_like(filter).find :all, limit: LIMIT
+      visible_groups = Group.with_access(current_user => :view)
+      visible_groups.named_like(filter).limit(LIMIT)
     end
   end
 
@@ -84,9 +80,8 @@ class EntitiesController < ApplicationController
       # preload user's groups
       User.friends_or_peers_of(current_user).all_with_access(current_user => :view)
     elsif filter.present?
-      strangers = User.strangers_to(current_user)
-      strangers = strangers.with_access(public: :view)
-      strangers.named_like(filter).find(:all, limit: LIMIT)
+      visible_users = User.with_access(current_user => :view)
+      visible_users.named_like(filter).limit(LIMIT)
     end
   end
 

--- a/app/models/unauthenticated_user.rb
+++ b/app/models/unauthenticated_user.rb
@@ -40,6 +40,7 @@ class UnauthenticatedUser
   def groups
     Group.none
   end
+  alias_method :all_groups, :groups
 
   def member_of?(group)
     false
@@ -48,6 +49,9 @@ class UnauthenticatedUser
   def friend_of?(user)
     false
   end
+
+  def friend_ids; [] ; end
+  def peer_ids;   [] ; end
 
   def method_missing(method)
     raise PermissionDenied.new("Tried to access #{method} on an unauthorized user.")

--- a/app/models/user_extension/users.rb
+++ b/app/models/user_extension/users.rb
@@ -56,18 +56,18 @@ module UserExtension::Users
 
       # same result as user.friends, but makes use of cache.
       def self.friends_of(user)
-        where('users.id in (?)', user.friend_id_cache)
+        where('users.id in (?)', user.friend_ids)
       end
 
       def self.friends_or_peers_of(user)
-        where('users.id in (?)', user.friend_id_cache + user.peer_id_cache)
+        where('users.id in (?)', user.friend_ids + user.peer_ids)
       end
 
       # neither friends nor peers
       # used for autocomplete when we preloaded the friends and peers
       def self.strangers_to(user)
         where 'users.id NOT IN (?)',
-          user.friend_id_cache + user.peer_id_cache + [user.id]
+          user.friend_ids + user.peer_ids + [user.id]
       end
 
       ##

--- a/test/functional/entities_controller_test.rb
+++ b/test/functional/entities_controller_test.rb
@@ -65,25 +65,23 @@ class EntitiesControllerTest < ActionController::TestCase
   end
 
   def test_entities_respect_user_privacy
-    login_as :green
-    assert_equal ["blue"], users(:orange).friends.map(&:login)
-      "orange should only have blue as a friend."
+    login_as :gerrard
+    users(:red).revoke_access! public: :view
     xhr :get, :index, format: :json, view: :all, query: 're'
     assert_response :success
     response = ActiveSupport::JSON.decode(@response.body)
     assert_equal [], response["suggestions"],
-      "orange can't see red"
+      "gerrard can't see red after it removed public access"
   end
 
   def test_people_respect_user_privacy
-    login_as :green
-    assert_equal ["blue"], users(:orange).friends.map(&:login)
-      "orange should only have blue as a friend."
+    login_as :gerrard
+    users(:red).revoke_access! public: :view
     xhr :get, :index, format: :json, view: :users, query: 're'
     assert_response :success
     response = ActiveSupport::JSON.decode(@response.body)
     assert_equal [], response["suggestions"],
-      "orange can't see red"
+      "gerrard can't see red after it removed public access"
   end
 
   #  def test_querying_locations


### PR DESCRIPTION
So far these results were excluded because the client already had them.
Since preload occasionally fails these days this is a workaround to make the result
less problematic. If the preload did not happen normal autocomplete will still work.