### PR TITLE
stay on top of wiki pages - do not scroll to bottom

### DIFF
--- a/app/helpers/common/ui/layout_helper.rb
+++ b/app/helpers/common/ui/layout_helper.rb
@@ -102,11 +102,6 @@ module Common::Ui::LayoutHelper
     lines << '<script type="text/javascript">'
     #lines << localize_modalbox_strings
       lines << content_for(:script) if content_for?(:script)
-      if content_for?(:dom_loaded)
-        lines << 'document.observe("dom:loaded",function(){'
-        lines << content_for(:dom_loaded)
-        lines << '});'
-      end
     lines << '</script>'
 
     # make all IEs behave like IE 9

--- a/app/views/layouts/global/_head.html.haml
+++ b/app/views/layouts/global/_head.html.haml
@@ -9,6 +9,11 @@
   / begin scripts
   = crabgrass_javascripts
   / end scripts
+- if content_for?(:dom_loaded)
+  :javascript
+    document.observe("dom:loaded",function(){
+      #{content_for(:dom_loaded)}
+    });
 = csrf_meta_tag
 - if context_banner_style || @content_for_style
   :css


### PR DESCRIPTION
make sure that content_for :dom_loaded does not get cached. It can lead to all
kinds of funny results.

Obviously we want to move this into all app javascript. But for now let's just
keep it here.