### PR TITLE
remove caching of top menu and bring back tracking

### DIFF
--- a/app/controllers/common/application/tracking.rb
+++ b/app/controllers/common/application/tracking.rb
@@ -5,8 +5,12 @@ module Common::Application::Tracking
   # controllers should call this when they want to record a trackingevent.
   # e.g. in order to update the page view count.
   def track(options={})
+    options.reverse_merge! current_user: current_user,
+      group: @group,
+      user: @user,
+      action: :view
     if current_site.tracking
-      Tracking.delayed_insert({current_user: current_user, group: @group, user: @user, action: :view}.merge(options))
+      Tracking.insert_delayed options
     end
   end
 

--- a/app/controllers/groups/home_controller.rb
+++ b/app/controllers/groups/home_controller.rb
@@ -19,6 +19,7 @@ class Groups::HomeController < Groups::BaseController
   def show
     @pages = Page.paginate_by_path '/descending/updated_at/limit/30/',
       options_for_group(@group), pagination_params
+    track
   end
 
   protected

--- a/app/controllers/people/home_controller.rb
+++ b/app/controllers/people/home_controller.rb
@@ -13,6 +13,7 @@ class People::HomeController < People::BaseController
 
   def show
     @profile = @user.profiles.public
+    track
   end
 
 end

--- a/app/views/layouts/global/nav/_top_menus.html.haml
+++ b/app/views/layouts/global/nav/_top_menus.html.haml
@@ -13,12 +13,11 @@
     %a.navbar-brand(href="/")
     -# %img{:src => current_theme.url('logo.png')}
   %ul.nav.navbar-nav
-    - cache [current_theme, current_language, current_user, active_top_nav.try.name] do
-      - @navigation[:global].each do |tab|
-        - if tab.visible
-          %li{class: "#{:active if tab.active} top-menu", id: "menu_#{tab.name}"}
-            = link_to(tab.label, tab.url)
-            = theme_render(tab.html)
+    - @navigation[:global].each do |tab|
+      - if tab.visible
+        %li{class: "#{:active if tab.active} top-menu", id: "menu_#{tab.name}"}
+          = link_to(tab.label, tab.url)
+          = theme_render(tab.html)
   %ul.nav.navbar-nav.navbar-right
     - if logged_in?
       %li.tab.account.last


### PR DESCRIPTION
track visits to group and user home controllers for now

This should provide the last_visited data for the drop down menu for groups and users.
It requires the CronController#tracking_update_hourlies to be called regularly.