### PR TITLE
debug output to fix NoMethodError in GroupSettings

### DIFF
--- a/app/helpers/common/ui/avatar_helper.rb
+++ b/app/helpers/common/ui/avatar_helper.rb
@@ -66,6 +66,11 @@ module Common::Ui::AvatarHelper
 
     return avatar_for(entity,'large') + "&nbsp;".html_safe +
       link_to_modal(:upload_image_link.t, link_options, class: 'inline')
+  rescue NoMethodError
+    Rails.logger.info "context: " + context.inspect
+    Rails.logger.info "entity: " + entity.inspect
+    Rails.logger.info "@group: " + @group.inspect
+    raise
   end
 end
 


### PR DESCRIPTION
Here's the error from the logs:
```
ActionView::Template::Error (undefined method `edit_context_avatar_path' for #<#<Class:0x007fee262424c8>:0x007fee26222e48>):
    15:       - r.info I18n.t(:descriptive_name_for_display)
    16:     - f.row do |r|
    17:       - r.label :icon.t
    18:       - r.input avatar_field(@group.becomes Group)
    19:     - f.heading :locale.t
    20:     - f.row do |r|
    21:       - r.label :language.t
  app/helpers/common/ui/avatar_helper.rb:63:in `avatar_field'
  app/views/groups/settings/show.html.haml:18:in `block (3 levels) in _app_views_groups_settings_show_html_haml___534312476661232484_70330409355620'
  app/views/groups/settings/show.html.haml:16:in `block (2 levels) in _app_views_groups_settings_show_html_haml___534312476661232484_70330409355620'
  vendor/crabgrass_plugins/crabgrass_formy/lib/formy/helper.rb:9:in `formy'
  app/views/groups/settings/show.html.haml:3:in `block in _app_views_groups_settings_show_html_haml___534312476661232484_70330409355620'
  app/views/groups/settings/show.html.haml:2:in `_app_views_groups_settings_show_html_haml___534312476661232484_70330409355620'
```

It sometimes shows up for Group Settings - no way to debug properly yet.