### PR TITLE
fix editing private posts

### DIFF
--- a/app/views/common/posts/default/_edit.html.haml
+++ b/app/views/common/posts/default/_edit.html.haml
@@ -5,7 +5,7 @@
 -#
 
 %div.post_body{id: post.body_id}
-  = form_for post, url: post_path(post), remote: true, method: :put,
+  = form_for post.becomes(Post), url: post_path(post), remote: true, method: :put,
     html: {onsubmit: show_spinner('edit_post')} do |f|
     = f.text_area :body, rows: 8, class: 'form-control'
     .buttons-right

--- a/test/integration/message_test.rb
+++ b/test/integration/message_test.rb
@@ -1,17 +1,33 @@
 require 'javascript_integration_test'
 
 class MessageTest < JavascriptIntegrationTest
+  include Integration::Comments
 
 
   def test_sending_message
     msg = "Here is my Message"
     login users(:blue)
-    click_on 'Messages'
-    fill_in 'Recipient', with: 'red'
-    fill_in 'Message', with: msg
-    click_on 'Send'
+    send_message msg, to: 'red'
     assert_content msg
   end
+
+  def test_editing_message
+    msg = "Here is my Message"
+    new_msg = "Now here is something new!"
+    login users(:blue)
+    send_message msg, to: 'red'
+    edit_comment msg, new_msg
+    assert_content new_msg
+    assert_no_content msg
+  end
+
+  def send_message(msg, options = {})
+    click_on 'Messages'
+    fill_in 'Recipient', with: options[:to]
+    fill_in 'Message', with: msg
+    click_on 'Send'
+  end
+
 
 end
 


### PR DESCRIPTION
the private post has to become a Post first so the field name matches our
expectations in the update action.