### PR TITLE
Use ErrorApp middleware for NotFound exceptions

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -61,7 +61,7 @@ class AssetsController < ApplicationController
     thumb_name = thumb_name_from_path(path)
     if thumb_name
       thumb = @asset.thumbnail(thumb_name)
-      raise_not_found(:file.t) unless thumb
+      raise_not_found unless thumb
       thumb.generate
       thumb
     else
@@ -69,7 +69,7 @@ class AssetsController < ApplicationController
     end
   rescue Errno::ENOENT => e
     Rails.logger.warn "WARNING: Asset not found: #{thumb_name}"
-    raise_not_found :file.t
+    raise_not_found
   end
 
   #

--- a/app/controllers/common/application/alert_messages.rb
+++ b/app/controllers/common/application/alert_messages.rb
@@ -113,8 +113,21 @@ module Common::Application::AlertMessages
     end
   end
 
-  def raise_not_found(thing="")
-    raise ErrorNotFound.new(thing)
+  #
+  # We use the default rails error to trigger the ErrorApp middleware.
+  # This will then in turn call ExceptionsController#show as defined in
+  # config.exceptions_app
+  #
+  # Why?
+  # Because we need to get rid of all Controller state.
+  #  * Instance variables may leak information.
+  #  * Controller functions like setup_navigation may crash.
+  #
+  # At the same time redirect would alter the url in the users browser.
+  # Maybe they just typed it wrong. So we better leave it there.
+  #
+  def raise_not_found
+    raise ActionController::RoutingError.new('Not Found')
   end
 
   def raise_denied(message=nil)

--- a/app/controllers/common/application/alert_messages.rb
+++ b/app/controllers/common/application/alert_messages.rb
@@ -127,7 +127,7 @@ module Common::Application::AlertMessages
   # Maybe they just typed it wrong. So we better leave it there.
   #
   def raise_not_found
-    raise ActionController::RoutingError.new('Not Found')
+    raise ActiveRecord::RecordNotFound
   end
 
   def raise_denied(message=nil)
@@ -135,7 +135,7 @@ module Common::Application::AlertMessages
   end
 
   def raise_authentication_required
-    raise AuthenticationRequired.new
+    raise AuthenticationRequired
   end
 
   private

--- a/app/controllers/context_pages_controller.rb
+++ b/app/controllers/context_pages_controller.rb
@@ -33,19 +33,22 @@ class ContextPagesController < DispatchController
   def process(*)
     super
   rescue ActiveRecord::RecordNotFound
+    warning :thing_not_found.t(thing: :page.t)
     redirect_to_new_page || raise_not_found
   end
 
   protected
- 
-  def redirect_to_new_page 
+
+  def redirect_to_new_page
     return unless logged_in?
 
     new_page_owner = @group || (@user if (@user == current_user ))
     return unless new_page_owner
 
-    url = create_page_url :type => 'wiki', 
-      page: { owner: new_page_owner, title: params[:_page] }
+    title = params[:id].split('+')[0...-1].join(' ').humanize
+    url = page_creation_url owner: new_page_owner,
+      type: :wiki,
+      page: { title: params[:id].humanize }
     logger.info("Redirect to #{url}")
 
     # FIXME: this controller isn't fully set-up yet (because usually the request

--- a/app/controllers/context_pages_controller.rb
+++ b/app/controllers/context_pages_controller.rb
@@ -99,8 +99,7 @@ class ContextPagesController < DispatchController
       end
     end
 
-    raise ActiveRecord::RecordNotFound.new unless @page
-    return controller_for_page(@page)
+    controller_for_page(@page) || raise_not_found
   end
 
   def find_pages_with_unknown_context(name)
@@ -120,6 +119,7 @@ class ContextPagesController < DispatchController
   #end
 
   def controller_for_page(page)
+    return unless page
     new_controller page.controller
   end
 

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -1,0 +1,28 @@
+class ExceptionsController < ApplicationController
+  layout 'application'
+
+  def show
+    @exception       = env['action_dispatch.exception']
+    @former_params   = env["action_dispatch.request.parameters"]
+    @status_code     = ActionDispatch::ExceptionWrapper.new(env, @exception).status_code
+    @rescue_response = ActionDispatch::ExceptionWrapper.rescue_responses[@exception.class.name]
+
+    respond_to do |format|
+      format.html { render :show, status: @status_code, layout: !request.xhr? }
+      format.xml  { render xml: details, root: "error", status: @status_code }
+      format.json { render json: {error: details}, status: @status_code }
+      format.js   { render_error_js(exception) }
+    end
+  end
+
+  protected
+
+  def details
+    @details ||= {
+      title:       I18n.t(@rescue_response, scope: "exception.title", cascade: true),
+      description: I18n.t(@rescue_response, scope: "exception.description", cascade: true)
+    }
+  end
+  helper_method :details
+
+end

--- a/app/controllers/groups/base_controller.rb
+++ b/app/controllers/groups/base_controller.rb
@@ -15,6 +15,7 @@ class Groups::BaseController < ApplicationController
   def fetch_group
     # group might be preloaded by DispatchController
     @group ||= Group.find_by_name(params[:group_id] || params[:id])
+    raise_not_found unless may_show_group?
   end
 
   def setup_context

--- a/app/controllers/groups/home_controller.rb
+++ b/app/controllers/groups/home_controller.rb
@@ -2,7 +2,6 @@ class Groups::HomeController < Groups::BaseController
 
   skip_before_filter :login_required
   guard :may_show_group?
-  rescue_from PermissionDenied, with: :render_not_found
 
   before_filter :fetch_wikis
 

--- a/app/controllers/groups/memberships_controller.rb
+++ b/app/controllers/groups/memberships_controller.rb
@@ -35,16 +35,13 @@ class Groups::MembershipsController < Groups::BaseController
   # add someone directly to a group
   #
   def create
-    if @group && @user
-      @group.add_user! @user
-      index # load @memberships
-      success
-      render :update do |page|
-        standard_update(page)
-        page.replace 'group_membership_list', partial: 'groups/memberships/list'
-      end
-    else
-      raise_not_found params[:user_name]
+    raise_not_found unless @group && @user
+    @group.add_user! @user
+    index # load @memberships
+    success
+    render :update do |page|
+      standard_update(page)
+      page.replace 'group_membership_list', partial: 'groups/memberships/list'
     end
   end
 

--- a/app/controllers/groups/pages_controller.rb
+++ b/app/controllers/groups/pages_controller.rb
@@ -2,7 +2,6 @@ class Groups::PagesController < Groups::BaseController
 
   skip_before_filter :login_required
   guard :may_show_group?
-  rescue_from PermissionDenied, with: :render_not_found
   
   include_controllers 'common/page_search'
 

--- a/app/controllers/pages/attributes_controller.rb
+++ b/app/controllers/pages/attributes_controller.rb
@@ -16,17 +16,22 @@ class Pages::AttributesController < Pages::SidebarsController
       @page.updated_by = current_user
       @page.save!
       render(:update) {|page| page.replace 'public_li', public_line}
-    elsif params[:owner]
-      if params[:owner] == current_user.name
-        owner = current_user
-      else
-        owner = Group.find_by_name params[:owner]
-      end
-      raise_not_found(:owner.t) unless owner
+    elsif owner
       @page.owner = owner
       @page.save!
       redirect_to page_path(@page)
       success
+    end
+  end
+
+  protected
+
+  def owner
+    return unless params[:owner]
+    if params[:owner] == current_user.name
+      current_user
+    else
+      Group.where(name: params[:owner]).first!
     end
   end
 

--- a/app/controllers/pages/before_filters.rb
+++ b/app/controllers/pages/before_filters.rb
@@ -18,9 +18,7 @@ module Pages::BeforeFilters
   #
   def default_fetch_data
     @page ||= Page.find(params[:page_id] || params[:id])
-    unless @page && may_show_page?
-      raise_not_found(:page.t)
-    end
+    raise_not_found unless may_show_page?
 
     if logged_in?
       # grab the current user's participation from memory

--- a/app/controllers/pages/create_controller.rb
+++ b/app/controllers/pages/create_controller.rb
@@ -69,14 +69,13 @@ class Pages::CreateController < ApplicationController
   end
 
   def set_owner
-    # owner from form 
-    owner_param = params[:page].delete(:owner) if params[:page].present? 
-    
+    # owner from form
+    owner_param = params[:page].delete(:owner) if params[:page].present?
+
     # owner from context
     owner_param ||= params[:owner]
-    
-    @owner = current_user if owner_param == 'me'
-    @owner ||= Group.find_by_name(owner_param) if owner_param.present?
+
+    @owner = Group.find_by_name(owner_param) if owner_param.present?
   end
 
   #

--- a/app/controllers/pages/sidebars_controller.rb
+++ b/app/controllers/pages/sidebars_controller.rb
@@ -29,9 +29,6 @@ class Pages::SidebarsController < ApplicationController
 
   def fetch_page
     @page = Page.find params[:page_id]
-    unless @page
-      raise_not_found(:page.t)
-    end
     if logged_in?
       # grab the current user's participation from memory
       @upart = @page.participation_for_user(current_user)

--- a/app/controllers/people/base_controller.rb
+++ b/app/controllers/people/base_controller.rb
@@ -11,11 +11,8 @@ class People::BaseController < ApplicationController
   def fetch_person
     # person might be preloaded by DispatchController
     @user ||= User.find_by_login(params[:person_id] || params[:id])
-    unless current_user.may?(:view, @user)
-      # let's make sure this looks like a failing dispatch
-      @user = nil
-      raise_not_found(:page.t)
-    end
+
+    raise_not_found unless current_user.may?(:view, @user)
   end
 
   def setup_context

--- a/app/controllers/people/base_controller.rb
+++ b/app/controllers/people/base_controller.rb
@@ -10,8 +10,7 @@ class People::BaseController < ApplicationController
 
   def fetch_person
     # person might be preloaded by DispatchController
-    @user ||= User.find_by_login(params[:person_id] || params[:id])
-
+    @user ||= User.where(login: (params[:person_id] || params[:id])).first!
     raise_not_found unless current_user.may?(:view, @user)
   end
 

--- a/app/controllers/wikis/locks_controller.rb
+++ b/app/controllers/wikis/locks_controller.rb
@@ -21,7 +21,9 @@ class Wikis::LocksController < Wikis::BaseController
   #
   def destroy
     @wiki.release_my_lock!(@section, current_user)
-    render nothing: true
+    head :accepted
+  rescue Wiki::SectionNotFound
+    head :not_found
   end
 
 end

--- a/app/controllers/wikis/versions_controller.rb
+++ b/app/controllers/wikis/versions_controller.rb
@@ -32,7 +32,7 @@ class Wikis::VersionsController < Wikis::BaseController
     @version = @wiki.find_version(params[:id])
   rescue Wiki::VersionNotFoundError => ex
     error ex
-    raise_not_found
+    redirect_to action: :index
   end
 
 end

--- a/app/controllers/wikis/versions_controller.rb
+++ b/app/controllers/wikis/versions_controller.rb
@@ -32,8 +32,7 @@ class Wikis::VersionsController < Wikis::BaseController
     @version = @wiki.find_version(params[:id])
   rescue Wiki::VersionNotFoundError => ex
     error ex
-    raise ErrorNotFound.new('Version')
-    return false
+    raise_not_found
   end
 
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -11,8 +11,9 @@ class Entity
 
   # returns a user or group with +name+ and throws a not found exception otherwise.
   def self.find_by_name!(name)
-    entity = User.find_by_login(name) || Group.find_by_name(name)
-    entity or raise ErrorNotFound.new("<strong>#{h name}</strong>")
+    User.where(login: name).first!
+  rescue ActiveRecord::RecordNotFound
+    Group.where(name: name).first!
   end
 
 end

--- a/app/models/wiki_extension/sections.rb
+++ b/app/models/wiki_extension/sections.rb
@@ -1,7 +1,7 @@
 module WikiExtension
   module Sections
 
-    class SectionNotFoundError < ErrorNotFound
+    class SectionNotFoundError < CrabgrassException
       def initialize(section = 'document', options = {})
         message = :cant_find_wiki_section.t(section: section)
         super(message)

--- a/app/permissions/groups/base_permission.rb
+++ b/app/permissions/groups/base_permission.rb
@@ -5,7 +5,7 @@ module Groups::BasePermission
   # allow immediate destruction for groups no larger than:
   MAX_SIZE_FOR_QUICK_DESTROY_GROUP = 3
 
-  # used from the home controller
+  # used from the home and pages controller
   def may_show_group?(group = @group)
     current_user.may? :view, group
   end

--- a/app/views/exceptions/show.html.haml
+++ b/app/views/exceptions/show.html.haml
@@ -1,0 +1,3 @@
+- content_for :title do 
+  %h1= details[:title]
+%p.lead= details[:description]

--- a/app/views/pages/create/_new_form.html.haml
+++ b/app/views/pages/create/_new_form.html.haml
@@ -9,14 +9,13 @@
   .h2.first
     .small= :create_a_new_thing.t(thing: :page.t.downcase)
     = page_type.class_display_name
-- if @group
-  %p= :page_added_to_group.t(group_type: @group.group_type.downcase, group_name: content_tag(:b,@group.name)).html_safe
+- if @owner.present?
+  %p= :page_added_to_group.t(group_type: @owner.group_type.downcase, group_name: content_tag(:b,@owner.name)).html_safe
 %hr
 
 .create_page
   = form_tag(create_page_path(page_type: page_type), multipart: @multipart) do
     = hidden_field_tag 'page_type', page_type
-    = hidden_field_tag('group', params[:group]) if params[:group]
     = formy(:horizontal_form) do |form|
       - @form_sections.each do |section|
         - if section =~ /\//

--- a/app/views/pages/create/_sharing.html.erb
+++ b/app/views/pages/create/_sharing.html.erb
@@ -1,6 +1,6 @@
 <%
   ## PAGE OWNER
-  if @owner and @owner != current_user
+  if @owner.present?
     form.hidden hidden_field_tag('page[owner]', @owner.name)
     form.row do |r|
       r.label :page_create_owner.t

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ if defined?(Bundler)
 end
 
 require_relative "../lib/crabgrass/boot.rb"
+require_relative "../lib/crabgrass/public_exceptions.rb"
 
 module Crabgrass
   class Application < Rails::Application
@@ -77,12 +78,7 @@ module Crabgrass
     # It will automatically turn deliveries on
     config.action_mailer.perform_deliveries = false
 
-    # we need a lambda because exceptions_controller is not initialized
-    # during config. 
-    # https://coderwall.com/p/w3ghqq/rails-3-2-error-handling-with-exceptions_app
-    config.exceptions_app = lambda do |env|
-      ExceptionsController.action(:show).call(env)
-    end
+    config.exceptions_app = Crabgrass::PublicExceptions.new(Rails.public_path)
 
     ##
     ## PLUGINS

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,13 @@ module Crabgrass
     # It will automatically turn deliveries on
     config.action_mailer.perform_deliveries = false
 
+    # we need a lambda because exceptions_controller is not initialized
+    # during config. 
+    # https://coderwall.com/p/w3ghqq/rails-3-2-error-handling-with-exceptions_app
+    config.exceptions_app = lambda do |env|
+      ExceptionsController.action(:show).call(env)
+    end
+
     ##
     ## PLUGINS
     ##

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Crabgrass::Application.configure do
   config.whiny_nils = true
   config.assets.compress = false
   config.assets.debug = true
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
   #config.action_view.debug_rjs                         = true
   config.action_controller.perform_caching              = false
   config.action_mailer.raise_delivery_errors = false

--- a/config/locales/en/exceptions.yml
+++ b/config/locales/en/exceptions.yml
@@ -1,0 +1,7 @@
+en:
+  exception:
+    not_found: Not Found
+    title:
+      not_found: Not Found
+    description:
+      not_found: Sorry, we could not find what you were looking for.

--- a/extensions/pages/gallery_page/test/functional/gallery_image_controller_test.rb
+++ b/extensions/pages/gallery_page/test/functional/gallery_image_controller_test.rb
@@ -24,8 +24,9 @@ class GalleryImageControllerTest < ActionController::TestCase
 
   def test_may_not_show
     login_as :red
-    xhr :get, :show, id: @asset.id, page_id: @gallery.id
-    assert_permission_denied
+    assert_not_found do
+      xhr :get, :show, id: @asset.id, page_id: @gallery.id
+    end
   end
 
   def test_may_show

--- a/extensions/pages/task_list_page/test/integration/task_list_test.rb
+++ b/extensions/pages/task_list_page/test/integration/task_list_test.rb
@@ -77,7 +77,7 @@ class TaskListTest < JavascriptIntegrationTest
 
   def complete_task
     within '#sort_list_pending' do
-      find('.check_off_16').click
+      first('.check_off_16').click
     end
   end
 

--- a/extensions/pages/wiki_page/test/functional/wiki_page_controller_test.rb
+++ b/extensions/pages/wiki_page/test/functional/wiki_page_controller_test.rb
@@ -12,9 +12,10 @@ class WikiPageControllerTest < ActionController::TestCase
   end
 
   def test_not_found_without_login
-    # existing page
-    get :show, id: pages(:wiki)
-    assert_not_found
+    assert_not_found do
+      # existing page
+      get :show, id: pages(:wiki)
+    end
   end
 
   def test_show_without_login

--- a/extensions/pages/wiki_page/test/functional/wikis/versions_controller_test.rb
+++ b/extensions/pages/wiki_page/test/functional/wikis/versions_controller_test.rb
@@ -37,7 +37,8 @@ class Wikis::VersionsControllerTest < ActionController::TestCase
     login_as :orange
     # should fail gracefully for non-existant version
     get :show, wiki_id: wiki.id, id: 7
-    assert_response 404
+    assert_response :redirect
+    assert_redirected_to action: :index
   end
 
   def test_revert

--- a/lib/crabgrass/exceptions.rb
+++ b/lib/crabgrass/exceptions.rb
@@ -33,20 +33,6 @@ class AssociationError < CrabgrassException; end
 # just report the error
 class ErrorMessage < CrabgrassException; end
 
-# report a not found error and return 404
-class ErrorNotFound < CrabgrassException
-  def initialize(thing, options={})
-    @thing = thing
-    super("",options)
-  end
-  def to_s
-    I18n.t(:thing_not_found, thing: @thing).capitalize
-  end
-  def status
-    :not_found
-  end
-end
-
 # a list of errors with a title. oooh lala!
 class ErrorMessages < ErrorMessage
   attr_accessor :title, :errors

--- a/lib/crabgrass/public_exceptions.rb
+++ b/lib/crabgrass/public_exceptions.rb
@@ -1,0 +1,27 @@
+#
+# ExceptionHandler for ActionDispatch Middleware.
+#
+# Will use routes to handle 404 and the files in public for 500 and 422
+#
+module Crabgrass
+  class PublicExceptions < ActionDispatch::PublicExceptions
+
+    def call(env)
+      render_with_exceptions_controller(env) || super
+    end
+
+    def render_with_exceptions_controller(env)
+      status = env["PATH_INFO"][1..-1]
+      return unless status == '404'
+      ExceptionsController.action(:show).call(env)
+    rescue Exception => controller_error
+      $stderr.puts <<-EOERR
+ERROR: ExceptionsController raised:
+  #{controller_error}.
+  #{controller_error.backtrace * "\n  "}
+EOERR
+      return false
+    end
+ 
+  end
+end

--- a/test/functional/contexts_controller_test.rb
+++ b/test/functional/contexts_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ContextsControllerTest < ActionController::TestCase
 
   def test_process_raises_not_found
-    assert_raises ErrorNotFound do
+    assert_raises ActiveRecord::RecordNotFound do
       get :show, id: 'pretty-sure-this-context-does-not-exist'
     end
     assert_nil assigns[:user]

--- a/test/functional/groups/home_controller_test.rb
+++ b/test/functional/groups/home_controller_test.rb
@@ -51,7 +51,9 @@ class Groups::HomeControllerTest < ActionController::TestCase
     login_as FactoryGirl.create(:user)
     @group.revoke_access! public: :view
     assert_permission :may_show_group?, false do
-      get :show, group_id: @group.to_param
+      assert_not_found do
+        get :show, group_id: @group.to_param
+      end
     end
   end
 

--- a/test/functional/groups/my_memberships_controller_test.rb
+++ b/test/functional/groups/my_memberships_controller_test.rb
@@ -8,7 +8,7 @@ class Groups::MyMembershipsControllerTest < ActionController::TestCase
   end
 
   def test_create
-    @group.grant_access! public: :join
+    @group.grant_access! public: [:join, :view]
     login_as @user
     assert_permission :may_join_group? do
       assert_difference '@group.users.count' do

--- a/test/functional/groups/permissions_controller_test.rb
+++ b/test/functional/groups/permissions_controller_test.rb
@@ -19,7 +19,7 @@ class Groups::PermissionsControllerTest < ActionController::TestCase
 
   def test_index_no_access
     login_as @other_user
-    assert_permission_denied do
+    assert_not_found do
       get :index, group_id: @group.to_param
     end
   end

--- a/test/functional/me/requests_controller_test.rb
+++ b/test/functional/me/requests_controller_test.rb
@@ -46,7 +46,8 @@ class Me::RequestsControllerTest < ActionController::TestCase
   def test_other_requests_hidden
     @user  = FactoryGirl.create(:user)
     login_as @user
-    get :show, id: Request.last
-    assert_not_found
+    assert_not_found do
+      get :show, id: Request.last
+    end
   end
 end

--- a/test/functional/pages/create_controller_test.rb
+++ b/test/functional/pages/create_controller_test.rb
@@ -1,6 +1,7 @@
 require_relative '../../test_helper'
 
 class Pages::CreateControllerTest < ActionController::TestCase
+  fixtures :all
 
   def setup
     @user  = FactoryGirl.create(:user)
@@ -9,9 +10,16 @@ class Pages::CreateControllerTest < ActionController::TestCase
   def test_new_page_view
     login_as @user
     get :new, owner: 'me', type: "wiki"
-    assert_equal assigns(:owner), @user
+    # if the owner is the current user we do not set it.
+    assert_nil assigns(:owner)
   end
 
+  def test_new_group_page_view
+    login_as users(:blue)
+    get :new, owner: 'rainbow', type: "wiki"
+    # if the owner is the current user we do not set it.
+    assert_equal groups(:rainbow), assigns(:owner)
+  end
 
   def test_create_page_for_myself
     login_as @user

--- a/test/functional/pages/trash_controller_test.rb
+++ b/test/functional/pages/trash_controller_test.rb
@@ -1,0 +1,34 @@
+require_relative '../../test_helper'
+
+class Pages::TrashControllerTest < ActionController::TestCase
+
+  def setup
+    @user = FactoryGirl.create(:user)
+    @page = FactoryGirl.create(:page, owner: @user)
+
+    assert @user, 'no user!'
+    assert @page, 'no page!'
+  end
+
+  def test_destroy
+    login_as @user
+    xhr :post, :update, page_id: @page.id, type: :destroy
+    assert_response :success
+    assert_equal [], Page.where(id: @page.id).all
+  end
+
+  def test_delete
+    login_as @user
+    xhr :post, :update, page_id: @page.id, type: :delete
+    assert_response :success
+    assert Page.where(id: @page).first.deleted?
+  end
+
+  def test_undelete
+    @page.delete
+    login_as @user
+    xhr :post, :update, page_id: @page.id, type: :undelete
+    assert_response :success
+    assert !Page.where(id: @page).first.deleted?
+  end
+end

--- a/test/functional/people/home_controller_test.rb
+++ b/test/functional/people/home_controller_test.rb
@@ -22,15 +22,17 @@ class People::HomeControllerTest < ActionController::TestCase
   def test_new_user_hidden
     user = FactoryGirl.create :user
     login_as :blue
-    get :show, person_id: user.login
-    assert_no_user_found
+    assert_not_found do
+      get :show, person_id: user.login
+    end
     user.destroy
   end
 
   def test_missing_user
     login_as :blue
-    get :show, person_id: "missinguserlogin"
-    assert_no_user_found
+    assert_not_found do
+      get :show, person_id: "missinguserlogin"
+    end
   end
 
   def test_new_user_visible_to_friends
@@ -43,11 +45,4 @@ class People::HomeControllerTest < ActionController::TestCase
     user.destroy
   end
 
-  # there should be no difference between a hidden user
-  # and a user not found...
-  def assert_no_user_found
-    assert_response 404
-    assert_nil assigns[:user]
-    assert_nil assigns[:group]
-  end
 end

--- a/test/functional/wikis/versions_controller_test.rb
+++ b/test/functional/wikis/versions_controller_test.rb
@@ -20,9 +20,9 @@ class Wikis::VersionsControllerTest < ActionController::TestCase
   end
 
   def test_version_not_found
-    assert_raises ActionController::RoutingError do
-      run_before_filters :show, wiki_id: @wiki.to_param, id: '123'
-    end
+    get :show, wiki_id: @wiki.to_param, id: '123'
+    assert_response :redirect
+    assert_redirected_to action: :index
   end
 
   def test_show

--- a/test/functional/wikis/versions_controller_test.rb
+++ b/test/functional/wikis/versions_controller_test.rb
@@ -20,7 +20,7 @@ class Wikis::VersionsControllerTest < ActionController::TestCase
   end
 
   def test_version_not_found
-    assert_raises ErrorNotFound do
+    assert_raises ActionController::RoutingError do
       run_before_filters :show, wiki_id: @wiki.to_param, id: '123'
     end
   end

--- a/test/helpers/functional_test_helper.rb
+++ b/test/helpers/functional_test_helper.rb
@@ -17,8 +17,17 @@ module FunctionalTestHelper
     assert_redirected_to root_path(redirect: @request.path)
   end
 
-  def assert_not_found
-    assert_response :not_found
+  NOT_FOUND_ERRORS = [
+    ActiveRecord::RecordNotFound
+  ]
+  def assert_not_found(&block)
+    if block_given?
+      assert_raises *NOT_FOUND_ERRORS do
+        yield
+      end
+    else
+      assert_response :not_found
+    end
   end
 
   # can pass either a regexp of the flash error string,

--- a/test/helpers/integration/content_assertions.rb
+++ b/test/helpers/integration/content_assertions.rb
@@ -14,9 +14,15 @@ module ContentAssertions
     assert_local_tab 'Home'
   end
 
-  def assert_not_found(thing = nil)
-    thing ||= :page.t
-    assert_content :thing_not_found.t(thing: thing)
+  NOT_FOUND_ERRORS = [
+    ActiveRecord::RecordNotFound
+  ]
+  # We use a Rack middleware to render the 404 page. It can't be tested
+  # in RackTest directly. So we just make sure a 404 is returned.
+  # The page rendered will be a verbose error page in test env but a
+  # simple 'Page not found' error page in production
+  def assert_not_found(&block)
+    assert_equal 404, page.status_code
   end
 
   def assert_login_failed

--- a/test/integration/page_access_test.rb
+++ b/test/integration/page_access_test.rb
@@ -13,7 +13,7 @@ class PageAccessTest < JavascriptIntegrationTest
     page.public = false
     page.save
     visit_page(page)
-    assert_content 'Not Found'
+    assert_not_found
   end
 
   def test_public_page_of_hidden_group

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -71,10 +71,6 @@ class PageSidebarTest < JavascriptIntegrationTest
     # finish deleting...
     assert_content 'Notices'
     assert_no_content own_page.title
-    visit path
-    assert_content 'Page not found'
-    # the additional user selector loads autocomplete
-    wait_for_ajax
   end
 
   def test_tag

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -73,6 +73,8 @@ class PageSidebarTest < JavascriptIntegrationTest
     assert_no_content own_page.title
     visit path
     assert_content 'Page not found'
+    # the additional user selector loads autocomplete
+    wait_for_ajax
   end
 
   def test_tag

--- a/test/integration/page_test.rb
+++ b/test/integration/page_test.rb
@@ -21,8 +21,7 @@ class PageTest < IntegrationTest
         visit "/#{page.owner_name}/#{page.name_url}"
         assert_equal other_user, page.reload.owner
         assert !page.public?
-        assert_content "Not Found"
-        assert_no_content other_user.display_name
+        assert_not_found
       end
     end
   end


### PR DESCRIPTION
We use the default rails error to trigger the ErrorApp middleware.
This will then in turn call ExceptionsController#show as defined in
config.exceptions_app

Why?
Because we need to get rid of all Controller state.
* Instance variables may leak information.
* Controller functions like setup_navigation may crash.

At the same time redirect would alter the url in the users browser.
Maybe they just typed it wrong. So we better leave it there.

I observed crashes based on Controller type / state in different 'not found' situations. Another example is this (trying to render pages of a group one may not access or that does not exist):

> Rendered error/not_found.html.haml within layouts/notice (0.3ms)
> ...
> ActionView::Template::Error (undefined method `filters' for nil:NilClass):
>   app/helpers/common/page/search_helper.rb:79:in `show_all?'
>   app/views/common/pages/search/_controls_active.html.haml:3
>   vendor/crabgrass_plugins/crabgrass_theme/lib/crabgrass/theme/helper.rb:11:in `theme_render'
>  app/views/layouts/local/_side_navigation.html.haml:16
> ...

The error occurs because `@path` is nil because the not_found was triggered in a before filter.
The controller still tries to render the side navigation though because it's a Group::PagesController.

