### PR TITLE
bugfix: display toc for wikis

### DIFF
--- a/extensions/pages/wiki_page/test/integration/wiki_test.rb
+++ b/extensions/pages/wiki_page/test/integration/wiki_test.rb
@@ -42,6 +42,20 @@ class WikiTest < JavascriptIntegrationTest
     end
   end
 
+  def test_wiki_toc
+    content = update_wiki <<-EOWIKI
+[[toc]]
+
+h1. test table of content
+
+h2. with nested section
+
+and some content
+    EOWIKI
+    assert_content 'table of content'
+    assert_selector 'li.toc1'
+  end
+
   def assert_wiki_unlocked
     request_urls = page.driver.network_traffic.map(&:url)
     assert request_urls.detect{|u| u.end_with? '/lock'}.present?
@@ -50,4 +64,5 @@ class WikiTest < JavascriptIntegrationTest
     # In order to prevent the check for pending ajax from failing...
     page.driver.clear_network_traffic
   end
+
 end

--- a/vendor/gems/riseuplabs-greencloth-0.1/lib/greencloth.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/lib/greencloth.rb
@@ -535,7 +535,7 @@ class GreenCloth < RedCloth::TextileDoc
     html.gsub!(MACROTAG_RE) do |m|
       macrotag = self.offtags[$1.to_i-1]
       method = 'symbol_'+macrotag[0]
-      if self.respond_to?(method)
+      if self.respond_to?(method, true)
         self.send(method)
       else
         "<p>#{macrotag[1]}</p>"

--- a/vendor/gems/riseuplabs-greencloth-0.1/test/lite_mode_test.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/test/lite_mode_test.rb
@@ -1,10 +1,12 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
+require 'yaml'
+require 'byebug'
 
 test_dir =  File.dirname(File.expand_path(__FILE__))
 require test_dir + '/../lib/greencloth.rb'
 
-class TestLiteMode < Test::Unit::TestCase
+class TestLiteMode < MiniTest::Test
 
   def setup
   end

--- a/vendor/gems/riseuplabs-greencloth-0.1/test/markup_test.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/test/markup_test.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
-require 'ruby-debug'
+require 'minitest/autorun'
+require 'byebug'
 require 'yaml'
-require 'test/unit'
 
 test_dir =  File.dirname(File.expand_path(__FILE__))
 require test_dir + '/../lib/greencloth.rb'
@@ -12,7 +12,7 @@ else
   nil
 end
 
-class TestMarkup < Test::Unit::TestCase
+class TestMarkup < MiniTest::Test
 
   def setup
     files = SINGLE_FILE_OVERRIDE || Dir[File.dirname(__FILE__) + "/fixtures/*.yml"]
@@ -41,7 +41,7 @@ class TestMarkup < Test::Unit::TestCase
   end
 
   def test_outline
-    return unless @fixtures['outline.yml']
+    assert @fixtures['outline.yml']
     @fixtures['outline.yml'].each do |doc|
       assert_markup('outline.yml', doc, GreenCloth.new(doc['in'], '', [:outline]).to_html)
     end

--- a/vendor/gems/riseuplabs-greencloth-0.1/test/outline_test.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/test/outline_test.rb
@@ -1,12 +1,12 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'rubygems'
-require 'ruby-debug'
 require 'yaml'
+require 'byebug'
 
 test_dir =  File.dirname(File.expand_path(__FILE__))
 require test_dir + '/../lib/greencloth.rb'
 
-class TestHeadings < Test::Unit::TestCase
+class TestHeadings < MiniTest::Test
 
   def setup
     testfile = File.dirname(__FILE__) + '/fixtures/outline.yml'
@@ -231,7 +231,7 @@ class TestHeadings < Test::Unit::TestCase
   def in_texts(name)
     name = name.to_s.gsub('_',' ')
     text = (@fixtures[name]||{})['in']
-    assert_not_nil text, 'could not find fixture data "%s"' % name
+    assert text, 'could not find fixture data "%s"' % name
     return text
   end
 


### PR DESCRIPTION
Fixes issue introduced by ruby2:
respond_to? will return false for protected methods.
http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html

This lead to toc not getting rendered for wikis.

Also ported the greencloth tests to ruby2. Some of them are still failing
but it seems they also were before.