### PR TITLE
Use container builds on travis - much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ addons:
   apt:
     packages:
       - graphicsmagick
-      - libreoffice-writer
-      - sphinxsearch
       - inkscape
 before_install:
   - "bundle --version"
-  - libreoffice --version
 before_script:
   - "bundle exec rake create_a_secret"
   - "cp config/database.yml.example config/database.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 # only install ci and assets gems:
 bundler_args: --without production:development:test
+sudo: false
 env:
   - RAKE_TASK=test
   - RAKE_TASK=test:pages:all
@@ -11,14 +12,15 @@ matrix:
   fast_finish: true
 #  allow_failures:
 #    - rvm: 2.0.0
+addons:
+  apt:
+    packages:
+      - graphicsmagick
+      - libreoffice-writer
+      - sphinxsearch
+      - inkscape
 before_install:
   - "bundle --version"
-  - sudo add-apt-repository ppa:libreoffice/libreoffice-4-3 -y
-  - sudo apt-get update -q
-  - sudo apt-get install -y graphicsmagick
-  - sudo apt-get install -y libreoffice-writer
-  - sudo apt-get install -y sphinxsearch
-  - sudo apt-get install -y inkscape
   - libreoffice --version
 before_script:
   - "bundle exec rake create_a_secret"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 # only install ci and assets gems:
 bundler_args: --without production:development:test
 sudo: false
+cache: bundler
 env:
   - RAKE_TASK=test
   - RAKE_TASK=test:pages:all


### PR DESCRIPTION
It seems we were not testing libreoffice functionality on travis anyway. At least the build is still green without it.

I will have to investigate both libreoffice and sphinx on travis and reduce the number of skipped tests.

But for now this makes travis so much faster so let's use container builds. :package: