### PR TITLE
rework group destruction to use rails powers

### DIFF
--- a/app/models/committee.rb
+++ b/app/models/committee.rb
@@ -98,8 +98,4 @@ class Committee < Group
     true
   end
 
-  def parent=(p)
-    raise 'call group.add_committee! instead'
-  end
-
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -35,7 +35,7 @@ class Group < ActiveRecord::Base
   include GroupExtension::Cache      # only versioning so far
 
   # not saved to database, just used by activity feed:
-  attr_accessor :created_by, :destroyed_by
+  attr_accessor :created_by
 
   # group <--> chat channel relationship
   has_one :chat_channel
@@ -262,36 +262,6 @@ class Group < ActiveRecord::Base
   before_save :save_avatar_if_needed
   def save_avatar_if_needed
     avatar.save if avatar and avatar.changed?
-  end
-
-  ##
-  ## DESTROY
-  ##
-
-  public
-
-  def destroy_by(user)
-    # needed for the activity
-    self.destroyed_by = user
-    # first we remove all the children in a clean way.
-    self.children.each {|committee| committee.destroy_by(user)}
-    # then we make sure they are not cached anymore so
-    # dependent: destroy does not get triggered.
-    # It would try to .destroy them which is a protected method.
-    self.reload
-    self.destroy
-  end
-
-  protected
-
-  # make destroy protected
-  # callers should use destroy_by
-  # TODO: this brakes Group.destroy_all - which is helpful for cleanup.
-  # I see how it can be useful to hide this from the api.
-  # But maybe we should do so by having a clear api and not by breaking
-  # the default rails api.
-  def destroy
-    super
   end
 
   ##

--- a/app/models/group_extension/groups.rb
+++ b/app/models/group_extension/groups.rb
@@ -16,13 +16,15 @@ module GroupExtension::Groups
       belongs_to :council, class_name: 'Group'
 
       # Committees are children! They must respect their parent group.
-      belongs_to :parent, class_name: 'Group'
+      belongs_to :parent, class_name: 'Group',
+        inverse_of: :children
       has_many :children, class_name: 'Group',
         foreign_key: :parent_id,
         order: 'name',
         after_add: :org_structure_changed,
         after_remove: :org_structure_changed,
-        dependent: :destroy
+        dependent: :destroy,
+        inverse_of: :parent
       alias_method :committees, :children
 
       has_many :real_committees,
@@ -107,7 +109,7 @@ module GroupExtension::Groups
     # should be used.
     def add_committee!(committee, make_council=false)
       make_council = true if committee.council?
-      committee.parent_id = self.id
+      committee.parent = self
       committee.parent_name_changed
       if make_council
         committee = add_council(committee)

--- a/app/models/group_extension/users.rb
+++ b/app/models/group_extension/users.rb
@@ -10,7 +10,6 @@ module GroupExtension::Users
   def self.included(base)
     base.instance_eval do
 
-      attr :users_before_destroy
       before_destroy :destroy_memberships
 #      before_create :set_created_by
 
@@ -156,9 +155,6 @@ module GroupExtension::Users
   protected
 
   def destroy_memberships
-    # save users before destroying memberships
-    # so that we still have them to create GroupDestroyedActivities for them
-    @users_before_destroy = users.dup
     user_names = []
     self.memberships.each do |membership|
       user = membership.user

--- a/app/models/mailers/group.rb
+++ b/app/models/mailers/group.rb
@@ -1,14 +1,14 @@
 module Mailers::Group
   def group_destroyed_notification(recipient, group, options)
     setup(options)
-    setup_destroyed_email(recipient, group)
+    setup_destroyed_email(recipient, group, options)
   end
 
   protected
 
-  def setup_destroyed_email(recipient, group)
+  def setup_destroyed_email(recipient, group, options)
     # @user may be nil
-    @user = group.destroyed_by
+    @user = options[:current_user]
     @group = group
     @recipients = "#{recipient.email}"
     @subject = I18n.t(:group_destroyed_subject,

--- a/app/models/observers/group_observer.rb
+++ b/app/models/observers/group_observer.rb
@@ -1,13 +1,5 @@
 class GroupObserver < ActiveRecord::Observer
 
-  # TODO: We should have Activities for groups not one per current member
-  def before_destroy(group)
-    key = rand(Time.now.to_i)
-    group.users_before_destroy.each do |recipient|
-      GroupDestroyedActivity.create!(groupname: group.name, recipient: recipient, destroyed_by: group.destroyed_by, key: key)
-    end
-  end
-
   def after_create(group)
     key = rand(Time.now.to_i)
     GroupCreatedActivity.create!(group: group, user: group.created_by, key: key)

--- a/test/unit/activity_test.rb
+++ b/test/unit/activity_test.rb
@@ -32,12 +32,13 @@ class ActivityTest < ActiveSupport::TestCase
   end
 
   def test_group_destroyed
-    groupname = @group.name
-    @group.destroy_by(@joe)
-
+    GroupDestroyedActivity.create! groupname: @group.name,
+      recipient: @joe,
+      destroyed_by: @joe,
+      key: rand(Time.now.to_i)
     acts = Activity.for_all(@joe).find(:all)
     act = acts.detect{|a|a.class == GroupDestroyedActivity}
-    assert_equal groupname, act.groupname
+    assert_equal @group.name, act.groupname
     assert_in_description(act, @group)
   end
 

--- a/test/unit/committee_test.rb
+++ b/test/unit/committee_test.rb
@@ -25,10 +25,10 @@ class CommitteeTest < ActiveSupport::TestCase
 
     assert_difference 'Group.find(%d).version'%g.id do
       assert_difference 'Group.find(%d).committees.count'%g.id, -1 do
-        c1.destroy_by(users(:red))
+        c1.destroy
       end
     end
-    g.destroy_by(users(:red))
+    g.destroy
     assert_nil Committee.find_by_name('food'), 'committee should die with group'
   end
 
@@ -36,7 +36,7 @@ class CommitteeTest < ActiveSupport::TestCase
     assert_nothing_raised do
       Group.find(groups(:warm).id)
     end
-    groups(:rainbow).destroy_by(users(:red))
+    groups(:rainbow).destroy
     assert_raises ActiveRecord::RecordNotFound, 'committee should be destroyed' do
       Group.find(groups(:warm).id)
     end

--- a/test/unit/council_test.rb
+++ b/test/unit/council_test.rb
@@ -64,7 +64,7 @@ class CouncilTest < ActiveSupport::TestCase
     g.add_committee!(council)
 
     council.add_user!(users(:blue))
-    council.destroy_by(users(:blue))
+    council.destroy
 
     g.reload
     assert_nil g.council
@@ -76,7 +76,7 @@ class CouncilTest < ActiveSupport::TestCase
     council = Council.create!(name: 'council')
     council.add_user!(users(:blue))
     network.add_committee!(council)
-    council.destroy_by(users(:blue))
+    council.destroy
 
     network.reload
     assert_nil network.council
@@ -91,7 +91,7 @@ class CouncilTest < ActiveSupport::TestCase
     g.add_committee!(council)
 
     council.add_user!(users(:blue))
-    g.destroy_by(users(:blue))
+    g.destroy
 
     assert_raises ActiveRecord::RecordNotFound do
       council.reload

--- a/test/unit/group_test.rb
+++ b/test/unit/group_test.rb
@@ -167,7 +167,7 @@ class GroupTest < ActiveSupport::TestCase
     assert_equal page.owner, g
 
     assert_difference 'Membership.count', -2 do
-      g.destroy_by(users(:blue))
+      g.destroy
     end
 
     assert_nil page.reload.owner_id
@@ -175,11 +175,6 @@ class GroupTest < ActiveSupport::TestCase
     red = users(:red)
     assert_nil GroupLostUserActivity.for_all(red).find(:first),
       "there should be no user left group message"
-
-    destroyed_act = GroupDestroyedActivity.for_all(red).unique.find(:first)
-    assert destroyed_act, "there should exist a group destroyed activity message"
-
-    assert_equal g.name, destroyed_act.groupname, "the activity should have the correct group name"
   end
 
   def test_avatar
@@ -215,7 +210,7 @@ class GroupTest < ActiveSupport::TestCase
     assert group.avatar.image_file_data.size > 0
 
     assert_difference 'Avatar.count', -1 do
-      group.destroy_by(users(:red))
+      group.destroy
     end
 
   end
@@ -234,13 +229,13 @@ class GroupTest < ActiveSupport::TestCase
     # groups are hidden by default
     group.profiles.public.update_attributes! may_see: true
 
-    assert !users(:blue).may?(:view, group), 
+    assert !users(:blue).may?(:view, group),
       "initially blue should not be able to view the group"
 
     group.migrate_permissions!
     users(:blue).clear_access_cache
 
-    assert users(:blue).may?(:view, group), 
+    assert users(:blue).may?(:view, group),
       "after migration blue should not be able to view the group"
   end
 

--- a/test/unit/pagination_test.rb
+++ b/test/unit/pagination_test.rb
@@ -23,7 +23,7 @@ class PaginationTest < ActiveSupport::TestCase
           group: group,
           page: page,
           action: :view,
-          time: Time.now - 2.days)
+          time: Time.now - 3.days)  # make sure trackings will be processed into dailies
       end
     end
 

--- a/test/unit/permission_test.rb
+++ b/test/unit/permission_test.rb
@@ -45,7 +45,7 @@ class PermissionTest < ActiveSupport::TestCase
     # destroy the council
     council.remove_user!(user)
     assert !user.may?(:admin, group), 'should be booted from council'
-    council.destroy_by(user)
+    council.destroy
     user.clear_access_cache
     assert user.may?(:admin, group), 'should be able to admin group again'
   end

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -164,7 +164,7 @@ class RequestTest < ActiveSupport::TestCase
     req = RequestToJoinUs.create(
       created_by: insider, recipient: outsider, requestable: group)
 
-    group.destroy_by(insider)
+    group.destroy
     assert_raises ActiveRecord::RecordNotFound, 'request should have been destroyed' do
       Request.find(req.id)
     end

--- a/test/unit/tracking_test.rb
+++ b/test/unit/tracking_test.rb
@@ -55,13 +55,16 @@ class TrackingTest < ActiveSupport::TestCase
         Daily.update
       end
     end
+    # we create trackings for the day before yesterday here
+    # - so they should be counted.
+    # And we add another day for caution because Hourlies store the timestamp at the end
+    # of the hour they were tracked in. So this will be on the next day in the hour
+    # before midnight.
     assert_difference 'Daily.count' do
-      # we create trackings for the day before yesterday here
-      # - so they should be counted.
+      # Hourly should be created for the tracked view
+      # but then removed after being processed for daily.
       assert_no_difference 'Hourly.count' do
-        # Hourly should be created for the tracked view
-        # but then removed after being processed for daily.
-        assert_tracking(user, group, page, action, Time.now - 2.days)
+        assert_tracking(user, group, page, action, Time.now - 3.days)
         Tracking.process
         Daily.update
       end


### PR DESCRIPTION
Observers are getting deprecated and it's really hard to figure out that they even exist.

Use the power of rails to remember associations of destroyed objects rather than
trying to capture these associations in additional attributes.

Keed the default rails association methods like parent= and group.destroy and use inverse_of to make sure the associated objects stay in sync.