### PR TITLE
bring back the context/page/print url - at least for wikis

### DIFF
--- a/app/helpers/wikis/base_helper.rb
+++ b/app/helpers/wikis/base_helper.rb
@@ -42,7 +42,7 @@ module Wikis::BaseHelper
       if options[:show_print].nil? || options[:show_print]
         formy.tab do |t|
           t.label :print.t
-          t.url print_wiki_url(wiki)
+          t.url wiki.page ? url_for(action: :print) : print_wiki_url(wiki)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,13 @@ Crabgrass::Application.routes.draw do
   ##
 
   resources :contexts, path: "", only: :show do
-    resources :pages, path: "", controller: :context_pages, except: [:index, :new, :create]
+    resources :pages, path: "",
+      controller: :context_pages,
+      except: [:index, :new, :create] do
+        member do
+          get 'print'
+        end
+      end
   end
 
   #

--- a/extensions/pages/wiki_page/app/controllers/wiki_page_controller.rb
+++ b/extensions/pages/wiki_page/app/controllers/wiki_page_controller.rb
@@ -15,6 +15,13 @@ class WikiPageController < Pages::BaseController
     end
   end
 
+  def print
+    if @page.try.discussion
+      @posts = @page.try.discussion.visible_posts.includes(:user)
+    end
+    render template: 'wikis/wikis/print', layout: 'printer_friendly'
+  end
+
   protected
 
   # called during BasePage::create

--- a/extensions/pages/wiki_page/config/routes.rb
+++ b/extensions/pages/wiki_page/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   scope path: 'pages' do
     resources :wikis, controller: :wiki_page, only: :show do
-      # TODO: bring back print view
-      #        get :print, on: :member
+      member do
+        get :print
+      end
     end
   end
 end


### PR DESCRIPTION
There's still a bunch of 404 from external links to this kind of url