### PR TITLE
prevent 500 for links that still use url encodes iso chars

### DIFF
--- a/test/functional/assets_controller_test.rb
+++ b/test/functional/assets_controller_test.rb
@@ -9,6 +9,14 @@ class AssetsControllerTest < ActionController::TestCase
     assert_login_required
   end
 
+  def test_get_with_escaped_chars
+    ImageAsset.any_instance.stubs(:public?).returns(false)
+    @controller.stubs(:authorized?).returns(true)
+    asset = FactoryGirl.create :image_asset
+    get :show, id: asset.id, path: asset.basename + '\xF3'
+    assert_response :success
+  end
+
   def test_thumbnail_get
     ImageAsset.any_instance.stubs(:public?).returns(false)
     asset = FactoryGirl.create :image_asset

--- a/test/integration/asset_test.rb
+++ b/test/integration/asset_test.rb
@@ -1,0 +1,25 @@
+require 'integration_test'
+
+class AssetTest < IntegrationTest
+
+  def test_get_asset
+    asset = FactoryGirl.create :image_asset
+    visit asset.url
+    assert_equal 200, status_code
+  end
+
+
+  # we used to have some iso encoding so links would escape to
+  # strings include %F3.
+  # Now this old link will lead to utf-8 errors as the chars > \xF0 are
+  # invalid. Let's make sure the old link still works...
+  def test_get_asset_with_strange_char
+    asset = FactoryGirl.create :image_asset
+    visit asset.url.sub('.jpg', '%F3.jpg')
+    assert_equal 200, status_code
+    visit asset.url.sub('.jpg', '%F3.jpg')
+    assert_equal 200, status_code
+  end
+end
+
+


### PR DESCRIPTION
We used some iso encoding before and that would turn some charectars into
%F3 and similar when url encoded.

Now that we switched to utf-8 some of those links still exist but lead to
utf-8 errors as characters above \xF0 are invalid. Since the exact filename
is not relevant for the assets controller anyway and this has been where we
saw the issue in production we will just drop the invalid chars in the utf-8
encoding.