### PR TITLE
update test environment - minitest 4.7 and mocha 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -221,8 +221,8 @@ group :test, :ci do
 
   gem 'factory_girl_rails'
   gem 'faker', '~> 1.0.0'
-  gem 'minitest', '~> 2.12', :require => false
-  gem 'mocha', '~> 0.12.0', :require => false
+  gem 'minitest', '~> 4.7', :require => false
+  gem 'mocha', '~> 1.1', :require => false
   #
   # mocha note: mocha must be loaded after the things it needs to patch.
   #             so, we skip the 'require' here, and do it later.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,8 @@ GEM
     metaclass (0.0.4)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (2.12.1)
-    mocha (0.12.10)
+    minitest (4.7.5)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.1)
     mysql2 (0.3.16)
@@ -254,8 +254,8 @@ DEPENDENCIES
   jsmin
   json (~> 1.8)
   mime-types
-  minitest (~> 2.12)
-  mocha (~> 0.12.0)
+  minitest (~> 4.7)
+  mocha (~> 1.1)
   mysql2 (~> 0.3)
   phantomjs-binaries (~> 1.8)
   poltergeist (~> 1.5)

--- a/app/controllers/groups/home_controller.rb
+++ b/app/controllers/groups/home_controller.rb
@@ -1,7 +1,8 @@
 class Groups::HomeController < Groups::BaseController
 
   skip_before_filter :login_required
-  guard :may_show_group?
+  # fetch_group already checks may_show_group?
+  skip_before_filter :authorization_required
 
   before_filter :fetch_wikis
 

--- a/app/controllers/groups/pages_controller.rb
+++ b/app/controllers/groups/pages_controller.rb
@@ -1,8 +1,9 @@
 class Groups::PagesController < Groups::BaseController
 
   skip_before_filter :login_required
-  guard :may_show_group?
-  
+  # fetch_group already checks may_show_group?
+  skip_before_filter :authorization_required
+
   include_controllers 'common/page_search'
 
   def index

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,3 @@
-#require 'rubygems'
-# we need to require test/unit because ActiveSupport::TestCase
-# derives from it and mocha will not patch it if it is not loaded
-# so the Mocha::API would not be available in AS::TestCase
-require 'test/unit'
-gem 'minitest', '~> 2.12'
 require 'minitest/autorun'
 
 ENV["RAILS_ENV"] = "test"

--- a/vendor/crabgrass_plugins/castle_gates/test/test.rb
+++ b/vendor/crabgrass_plugins/castle_gates/test/test.rb
@@ -3,7 +3,11 @@ require_relative 'test_helper'
 ## TEST
 ##
 
-class CastleGatesTest < Test::Unit::TestCase
+unless defined? Minitest::Test
+  class Minitest::Test < ActiveSupport::TestCase; end
+end
+
+class CastleGatesTest < Minitest::Test
 
   def setup
     @fort = Fort.find :first
@@ -22,6 +26,10 @@ class CastleGatesTest < Test::Unit::TestCase
     @bunker = Bunker.find :first
 
     #User.current = @me
+  end
+
+  def teardown
+    Fort.clear_key_cache
   end
 
   def test_argument_exception
@@ -68,7 +76,6 @@ class CastleGatesTest < Test::Unit::TestCase
       assert @fort.access?(@me => :draw_bridge), 'should have access now'
       assert !@fort.access?(@me => :door), 'defaults do not apply with set'
 
-      @fort.clear_key_cache
       raise ActiveRecord::Rollback
     end
   end

--- a/vendor/crabgrass_plugins/castle_gates/test/test_helper.rb
+++ b/vendor/crabgrass_plugins/castle_gates/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'rubygems'
 begin
   require 'byebug'
@@ -6,9 +6,11 @@ rescue LoadError  # ruby < 2.0.0
   require 'debugger'
 end
 require 'logger'
-gem 'actionpack', '~> 3.2.19'
-gem 'activerecord', '~> 3.2.19'
+gem 'actionpack', '~> 3.2.22'
+gem 'activerecord', '~> 3.2.22'
+gem 'railties', '~> 3.2.22'
 require 'active_record'
+require 'rails/engine'
 
 ##
 ## OPTIONS


### PR DESCRIPTION
Also allow me to run the castle_gates tests with minitest 5.6 which I have installed and which is used when tests are run without bundle exec.

Also make castle gates tests independent of run order
