### PR TITLE
Fix for tasks icon missed in the main menu

### DIFF
--- a/extensions/themes/default/navigation.rb
+++ b/extensions/themes/default/navigation.rb
@@ -94,7 +94,7 @@ define_navigation do
       label  { :tasks.t }
       url    { me_tasks_path }
       active { controller?('me/tasks') }
-      icon   :page_task
+      icon   :page_tasks
       local_section :pending do
         label  { :pending.t }
         url    { me_tasks_path }


### PR DESCRIPTION
Issue occurs because of the typo in the css class name

Bug: #9524
Link: https://labs.riseup.net/code/issues/9524

![9524_my_task_icon_missed](https://cloud.githubusercontent.com/assets/526022/8420175/97532036-1ec8-11e5-8465-15a90e5a9f8b.png)

Just need to start from something simple :wink: