### PR TITLE
Dismiss private message notification for deleted message

### DIFF
--- a/test/unit/private_message_notice_test.rb
+++ b/test/unit/private_message_notice_test.rb
@@ -1,0 +1,22 @@
+require_relative 'test_helper'
+
+class PrivateMessageNoticeTest < ActiveSupport::TestCase
+  fixtures :users
+
+  def test_post_deletion_dismiss_its_notice
+    blue, orange = users(:blue), users(:orange)
+    relationship = blue.add_contact! orange
+    relationship.send_message 'Hi, Orange! 1'
+    message_to_destroy = relationship.send_message 'Hi, Orange! 2'
+    assert_equal 2, PrivateMessageNotice.where(dismissed: false).count
+
+    message_to_destroy.destroy
+    assert_equal 1, PrivateMessageNotice.where(dismissed: false).count
+
+    private_notice_for_deleted_post = PrivateMessageNotice.last
+    assert private_notice_for_deleted_post.dismissed?
+    message_hash = { message: "<p>Hi, Orange! 2</p>", from: blue.name }
+    assert_equal message_hash, private_notice_for_deleted_post.data
+  end
+end
+


### PR DESCRIPTION
Hi!

Dismiss the private message notification for a reciever
if the message was deleted by a sender.
Do nothing if a reciever dissmissed it already.

Affects only private messages between users.

Feature: #8493
Link: https://labs.riseup.net/code/issues/8493

Maybe I missed something?