### PR TITLE
Update the Thin gem dependency for Ruby > 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -191,7 +191,11 @@ group :development do
   gem 'rdoc', '~> 3.0'
 
   # fast and light weight server
-  gem 'thin', :platforms => :mri_19, :require => false
+  if RUBY_VERSION > '2'
+    gem 'thin', :require => false
+  else
+    gem 'thin', :platforms => :mri_19, :require => false
+  end
 
   # speed up rails dev mode
   gem 'rails-dev-boost', :github => 'thedarkone/rails-dev-boost'


### PR DESCRIPTION
Hi!

I have faced a problem when the Thin server was not installed on the system with `Ruby 2.1.5`. And it have blocked running the application on my local machine.
So this simple conditional was added to fix it.

Actually I believe that `Ruby 1.9` is not receiving security update anymore. Maybe it is worth to drop support for it?

One more question. I saw another one condition for similar problem, like this:
```ruby
if Bundler.respond_to?(:current_ruby) &&
   Bundler.current_ruby.respond_to (:mri_21?)                                                                  
     gem 'byebug', :platforms => [:mri_20, :mri_21]                                                              
end  
```
Is there special need to check the Ruby version through the Bundler rather than `RUBY_VERSION` constant?
In case it is I may need to update this PR.

Thanks!