### PR TITLE
make comments and messages more robust

### DIFF
--- a/app/controllers/common/posts.rb
+++ b/app/controllers/common/posts.rb
@@ -39,14 +39,5 @@ module Common::Posts
     end
   end
 
-  protected
-
-  def render_posts_refresh(posts)
-    render :update do |page|
-      standard_update(page)
-      page.replace('posts', partial: 'common/posts/list', locals: {posts: posts})
-    end
-  end
-
 end
 

--- a/app/controllers/me/posts_controller.rb
+++ b/app/controllers/me/posts_controller.rb
@@ -24,11 +24,7 @@ class Me::PostsController < Me::BaseController
   def create
     in_reply_to = Post.find_by_id(params[:in_reply_to_id])
     current_user.send_message_to!(@recipient, params[:post][:body], in_reply_to)
-    if request.xhr?
-      render_posts_refresh(@discussion.posts.paginate(post_pagination_params))
-    else
-      redirect_to me_discussion_posts_url(@recipient)
-    end
+    redirect_to action: :index
   end
 
   protected
@@ -39,6 +35,7 @@ class Me::PostsController < Me::BaseController
       @discussion = current_user.discussions.from_user(@recipient).first
     end
     if @recipient.blank?
+      error(:thing_not_found.t(thing: :recipient.t), :later)
       redirect_to me_discussions_url
     end
     if params[:id] && @discussion

--- a/app/controllers/pages/posts_controller.rb
+++ b/app/controllers/pages/posts_controller.rb
@@ -12,6 +12,7 @@ class Pages::PostsController < ApplicationController
   before_filter :authorization_required
   guard :may_ALIAS_post?
   guard show: :may_show_page?
+  guard index: :may_show_page?
 
   track_actions :create, :update, :destroy
 
@@ -21,14 +22,21 @@ class Pages::PostsController < ApplicationController
   # do we still want this?...
   # cache_sweeper :social_activities_sweeper, :only => [:create, :save, :twinkle]
 
+  # js action to rerender the posts
+  def index
+    @posts = @page.posts(pagination_params)
+    @post = Post.new
+    # maybe? :anchor => @page.discussion.posts.last.dom_id), :paging => params[:paging] || '1')
+  end
+
   def show
     redirect_to page_url(@post.discussion.page) + "#posts-#{@post.id}"
   end
 
   def create
-    @post = @page.add_post(current_user, post_params)
-    # maybe? :anchor => @page.discussion.posts.last.dom_id), :paging => params[:paging] || '1')
-    render_posts_refresh @page.posts(pagination_params)
+    if @post = @page.add_post(current_user, post_params)
+      redirect_to action: :index
+    end
   end
 
   #

--- a/app/views/common/posts/_list_as_default.html.haml
+++ b/app/views/common/posts/_list_as_default.html.haml
@@ -8,16 +8,12 @@
 
 - local_assigns[:reply_body] ||= false
 - show_reply = local_assigns[:reply_body] || safe_call(:may_create_post?) || false
-
-- if posts.any?
-  - last_id = posts.last.id
-- else
-  - last_id = nil
+- last_id = posts.last.try.id
 
 = post_pagination_links(posts)
 %table.posts.round
   - for post in posts do
     = render partial: 'common/posts/default/row', locals: local_assigns.merge(post: post, last: (post.id == last_id))
   - if show_reply
-    = render partial: 'common/posts/default/reply', locals: local_assigns.merge(last_id: last_id)
+    = render partial: 'common/posts/default/reply', locals: local_assigns
 = post_pagination_links(posts)

--- a/app/views/common/posts/default/_reply_body.html.haml
+++ b/app/views/common/posts/default/_reply_body.html.haml
@@ -3,20 +3,15 @@
 -#   posts_path(*arg) -- must be defined, for creating.
 -#
 -# options:
--#   last_id -- set in_reply_to_id, which currently is just used for helping
--#              to generate the activity feed.
 -#   remote  -- if not nil, generate an ajax form.
 -#
 
 - remote = local_assigns[:remote] || false
-- # display the current post if it has unsaved changes
-- record = @post if @post.new_record? or @post.changed?
-- record ||= Post.new
-= form_for record, url: posts_path, remote: remote,
+= form_for @post, url: posts_path, remote: remote,
   html: {onsubmit: show_spinner('post')} do |f|
-  = hidden_field_tag('in_reply_to_id', last_id) if last_id
 
   -# not sure if these are still used, or how they are used:
+  =# hidden_field_tag('in_reply_to_id', last_id) if last_id
   =# hidden_field_tag('page_id', @page.id) if @page
   =# hidden_field_tag('paging', @discussion.last_page if @discussion
 

--- a/app/views/me/posts/index.js.rjs
+++ b/app/views/me/posts/index.js.rjs
@@ -1,0 +1,2 @@
+standard_update(page)
+page.replace 'posts', partial: 'common/posts/list'

--- a/app/views/pages/posts/index.js.rjs
+++ b/app/views/pages/posts/index.js.rjs
@@ -1,0 +1,2 @@
+standard_update(page)
+page.replace 'posts', partial: 'common/posts/list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Crabgrass::Application.routes.draw do
     #resources :changes
     resources :assets, only: [:index, :update, :create]
     resources :tags, only: [:index, :create, :destroy, :show]
-    resources :posts, except: [:index, :new]
+    resources :posts, except: [:new]
 
     # page sidebar/popup controllers:
     resource :sidebar,    only: [:show]

--- a/test/functional/pages/posts_controller_test.rb
+++ b/test/functional/pages/posts_controller_test.rb
@@ -39,7 +39,7 @@ class Pages::PostsControllerTest < ActionController::TestCase
   end
 
   def assert_successfully_posted_to(page)
-    assert_response :success
+    assert_response :redirect
     assert_equal 1, page.reload.posts.count
     assert_equal body, page.posts.first.body
     assert_equal @user, page.updated_by


### PR DESCRIPTION
We now use two controller actions ... one for generating the post and
then we redirect to one for rerendering the list of posts.

This way we can set @post to the created post in the creation action
and track it and have a new Post as @post in the index action.