### PR TITLE
cleanup: remove direct data upload from assets

### DIFF
--- a/app/models/asset_extension/upload.rb
+++ b/app/models/asset_extension/upload.rb
@@ -6,32 +6,18 @@
 
 require 'fileutils'
 
-## can be used to create assets from a script instead of uploaded from a browser:
-## asset = Asset.create_from_params :uploaded_data => FileData.new('/path/to/file')
-class FileData < String
-  attr_accessor :size, :original_filename, :content_type
-  def initialize(filename)
-    super(filename)
-    self.size = 1
-    self.original_filename = filename
-    self.content_type = Media::MimeType.mime_type_from_extension(filename)
-  end
-end
-
 module AssetExtension
   module Upload
+    extend ActiveSupport::Concern
 
-    def self.included(base)
+    included do
 
-      base.validate :validate_upload_data
-      base.before_validation :process_attachment
-      base.after_update :finalize_attachment  #  \  both are
-      base.after_create :finalize_attachment  #  /  needed
+      validate :validate_upload_data
+      before_validation :process_attachment
+      after_update :finalize_attachment  #  \  both are
+      after_create :finalize_attachment  #  /  needed
 
-      base.extend(ClassMethods)
-      base.instance_eval do
-        include InstanceMethods
-      end
+      attr_reader :uploaded_data
     end
 
     module ClassMethods
@@ -97,119 +83,92 @@ module AssetExtension
       end
     end
 
-    module InstanceMethods
 
-      def validate_upload_data
-        if new_record?
-          unless uploaded_data_changed?
-            errors.add(:uploaded_data, I18n.t('errors.messages.empty'))
-          end
+    def validate_upload_data
+      if new_record?
+        unless uploaded_data_changed?
+          errors.add(:uploaded_data, I18n.t('errors.messages.empty'))
         end
       end
+    end
 
-      #
-      # html forms for assets have a field called 'uploaded_data'. This setter
-      # will grab the uploaded file from that field. There is not actually a
-      # column in the db called 'uploaded_data'. the actual work is done in
-      # finalize_attachment
-      #
-      def uploaded_data=(file_data)
-        attribute_will_change!('uploaded_data') if file_data != @file_data
-        @file_data = file_data
+    #
+    # html forms for assets have a field called 'uploaded_data'. This setter
+    # will grab the uploaded file from that field. There is not actually a
+    # column in the db called 'uploaded_data'. the actual work is done in
+    # finalize_attachment
+    #
+    def uploaded_data=(file_data)
+      attribute_will_change!('uploaded_data') if file_data != @uploaded_data
+      @uploaded_data = file_data
+    end
+
+    def uploaded_data_changed?
+      changed.include? 'uploaded_data'
+    end
+
+    #
+    # called before validation in order to create @temp_file from the data and
+    # to extract meta-data. @temp_file is turned into permanent storage later on
+    # in finalize_attachment().
+    #
+    def process_attachment
+      if @uploaded_data
+        # temporarily capture old filenames
+        @old_files = self.all_filenames || []
+
+        # create @temp_file from uploaded file
+        self.content_type  = Asset.mime_type_from_data(@uploaded_data)
+        self.filename      = @uploaded_data.original_filename
+        self.filename_will_change! # just in case nothing is different, force dirty.
+        @temp_file = Media::TempFile.new(@uploaded_data, content_type)
+        @uploaded_data = nil
+
+        alter_asset_class(content_type)
+        extract_metadata(@temp_file)
       end
+      true
+    end
 
-      def uploaded_data
-        @file_data || @raw_data
+    #
+    # copies the temporary files to permanent storage.
+    # called after creation and every update.
+    #
+    def finalize_attachment
+      if @old_files
+        remove_files(*@old_files)
+        @old_files.clear
+        @old_files = nil
       end
-
-      def uploaded_data_changed?
-        changed.include? 'uploaded_data'
+      if @temp_file
+        save_to_storage(@temp_file.path)
+        @temp_file.clear
+        @temp_file = nil
+        create_thumbnail_records
       end
+      true
+    end
 
-      #
-      # some POSTs may encode the data in the params directly as a blob, instead of
-      # as an uploaded file. This setter will grab the raw blob and create a file
-      # from it (the file is actually created later in finalize_attachment).
-      #
-      def data=(raw_data)
-        attribute_will_change!('uploaded_data') if raw_data != @raw_data
-        @raw_data = raw_data
+    private
+
+    # if the asset class has changed, then we change the type column for this
+    # model. the next time this object is loaded, it will be a different class.
+    def alter_asset_class(content_type)
+      asset_class = Asset.class_for_mime_type(content_type)
+      if self.class != asset_class
+        self.thumbnails.clear
+        self.type = Media::MimeType.asset_class_from_mime_type(content_type)
+        self.thumbdefs = asset_class.class_thumbdefs
       end
+    end
 
-      #
-      # called before validation in order to create @temp_file from the data and
-      # to extract meta-data. @temp_file is turned into permanent storage later on
-      # in finalize_attachment().
-      #
-      def process_attachment
-        if uploaded_data
-          # temporarily capture old filenames
-          @old_files = self.all_filenames || []
-
-          # create @temp_file
-          if @file_data
-            # handle an uploaded file
-            self.content_type  = Asset.mime_type_from_data(@file_data)
-            self.filename      = @file_data.original_filename
-            self.filename_will_change! # just in case nothing is different, force dirty.
-            @temp_file = Media::TempFile.new(@file_data, content_type)
-            @file_data = nil
-          elsif @raw_data
-            # handle raw data
-            @temp_file = Media::TempFile.new(@raw_data, content_type)
-            @raw_data = nil
-          end
-
-          if @temp_file
-            alter_asset_class(content_type)
-            extract_metadata(@temp_file)
-          end
-        end
-        true
+    def extract_metadata(file)
+      self.size = File.size(file.path)
+      if Media.has_dimensions?(self.content_type)
+        self.width, self.height = Media.dimensions(file.path)
       end
-
-      #
-      # copies the temporary files or raw data to permanent storage.
-      # called after creation and every update.
-      #
-      def finalize_attachment
-        if @old_files
-          remove_files(*@old_files)
-          @old_files.clear
-          @old_files = nil
-        end
-        if @temp_file
-          save_to_storage(@temp_file.path)
-          @temp_file.clear
-          @temp_file = nil
-          create_thumbnail_records
-        end
-        true
-      end
-
-      private
-
-      # if the asset class has changed, then we change the type column for this
-      # model. the next time this object is loaded, it will be a different class.
-      def alter_asset_class(content_type)
-        asset_class = Asset.class_for_mime_type(content_type)
-        if self.class != asset_class
-          self.thumbnails.clear
-          self.type = Media::MimeType.asset_class_from_mime_type(content_type)
-          self.thumbdefs = asset_class.class_thumbdefs
-        end
-      end
-
-      def extract_metadata(file)
-        self.size = File.size(file.path)
-        if Media.has_dimensions?(self.content_type)
-          self.width, self.height = Media.dimensions(file.path)
-        end
-      end
-
     end
 
   end
+
 end
-
-

--- a/extensions/pages/asset_page/test/unit/asset_page_test.rb
+++ b/extensions/pages/asset_page/test/unit/asset_page_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require 'test_helper'
 
 class AssetPageTest < ActiveSupport::TestCase
   fixtures :users, :assets
@@ -33,15 +33,6 @@ class AssetPageTest < ActiveSupport::TestCase
     page.save!
     assert File.exist?(asset.private_filename)
     assert !File.exist?(asset.public_filename), 'public file "%s" should NOT exist' % asset.public_filename
-  end
-
-  # make sure assigning page.data later still updates permissions.
-  def test_asset_page_alt_method
-    page = AssetPage.create! title: 'perm test', user: users(:blue)
-    asset = Asset.create! data: 'hi', filename: 'x'
-    page.data = asset
-    page.save!
-    assert asset.visible?(users(:blue))
   end
 
   protected

--- a/test/unit/asset_test.rb
+++ b/test/unit/asset_test.rb
@@ -262,24 +262,10 @@ class AssetTest < ActiveSupport::TestCase
     assert_equal 'application/octet-stream', Asset.new.content_type
   end
 
-  # data without a file upload, but just from memory
-  def test_direct_data
-    data1 = '<b>this is some very interesting data</b>'
-    data2 = '<i>but not this</i>'
-
-    asset = Asset.create!(data: '<b>this is some very interesting data</b>', content_type: 'text/html', filename: 'data')
-    assert_equal data1, File.read(asset.private_filename)
-
-    asset.data = data2
-    asset.save
-
-    assert_equal data2, File.read(asset.private_filename)
-    assert_equal data1, File.read(asset.versions.earliest.private_filename)
-  end
-
   def test_user_versions
-    asset = Asset.create! data: 'hi', filename: 'x'
-    asset.update_attributes data: 'bye', user: users(:blue)
+    asset = Asset.create! uploaded_data: upload_data('empty.jpg')
+    asset.update_attributes user: users(:blue),
+      uploaded_data: upload_data('photo.jpg')
     assert_nil asset.versions.first.user
     assert_equal users(:blue), asset.versions.last.user
   end


### PR DESCRIPTION
We're not using it and it adds quite a bit of complexity