### PR TITLE
Fix for incremental images upload to a gallery with Drag'n'Drop

### DIFF
--- a/app/assets/javascripts/crabgrass/upload/handleEvents.js
+++ b/app/assets/javascripts/crabgrass/upload/handleEvents.js
@@ -13,34 +13,34 @@ ajaxUpload.handleInput = function (_fileInput) {
 ajaxUpload.handleDragAndDrop = function (fileDrop) {
   if (!fileDrop) return;
 
-  fileDrop.addEventListener("drop", onFileDropped, true);
-  fileDrop.addEventListener("dragenter", onDragEnter, true);
-  fileDrop.addEventListener("dragover", onDragOver, true);
-  fileDrop.addEventListener("dragleave", onDragLeave, true);
+  fileDrop.ondrop      = onFileDropped;
+  fileDrop.ondragenter = onDragEnter;
+  fileDrop.ondragover  = onDragOver;
+  fileDrop.ondragleave = onDragLeave;
 
   function onFileDropped(e) {
     e.currentTarget.classList.remove("dragging");
     ajaxUpload.files.add(e.dataTransfer.files);
-    e.stopPropagation();  
-    e.preventDefault(); 
+    e.stopPropagation();
+    e.preventDefault();
   }
 
   function onDragEnter(e) {
     e.currentTarget.classList.add("dragging");
-    e.stopPropagation();  
-    e.preventDefault(); 
+    e.stopPropagation();
+    e.preventDefault();
   }
 
   function onDragOver(e) {
     e.currentTarget.classList.add("dragging");
-    e.stopPropagation();  
-    e.preventDefault(); 
+    e.stopPropagation();
+    e.preventDefault();
   }
 
   function onDragLeave(e) {
     e.currentTarget.classList.remove("dragging");
-    e.stopPropagation();  
-    e.preventDefault(); 
+    e.stopPropagation();
+    e.preventDefault();
   }
 
 };


### PR DESCRIPTION
Issue description:
When user uploads an image to a gallery using the
Drag'n'Drop feature, upload occurs incrementally,
that leads to massive amount of duplicates in a gallery.

The fix is the replacing already assigned events on existent
DOM elements to prevent same events assigned each time
ajaxUpload reinitialized.

Bug: #9656
Link: https://labs.riseup.net/code/issues/9656

---
`ajaxUpload` reinitialized each time we upload the image. So usage of `addEventListener` adds event duplicates on form, that leads to problem mentioned above.
`inline` javascript event attachment replace existent ones, so we control it.

The sad story is how I debugged it until found the reason :sob:

And still not sure, maybe it is better just to prevent double reinitialization of `ajaxUpload`:
```bash
app/assets/javascripts/crabgrass/upload.js
4:  initAjaxUpload();

app/views/common/assets/destroy.js.rjs
4:page << 'if (initAjaxUpload) initAjaxUpload();'

app/views/pages/assets/create.js.rjs
3:page << 'initAjaxUpload();'

app/views/wikis/assets/create.js.rjs
2:page << 'initAjaxUpload();'

app/helpers/pages/sidebar_helper.rb
193:        after_load: 'initAjaxUpload();'

app/helpers/wikis/base_helper.rb
65:        complete: "initAjaxUpload();"
```