### PR TITLE
bugfix: turn pages public and private without error

### DIFF
--- a/app/models/page_history.rb
+++ b/app/models/page_history.rb
@@ -107,7 +107,7 @@ class PageHistory::Update < PageHistory
 
   protected
 
-  def class_for_update(page)
+  def self.class_for_update(page)
     return PageHistory::MakePrivate if page.marked_as_private?
     return PageHistory::MakePublic if page.marked_as_public?
     # return PageHistory::ChangeOwner if page.owner_id_changed?

--- a/test/helpers/integration/javascript/page_actions.rb
+++ b/test/helpers/integration/javascript/page_actions.rb
@@ -50,6 +50,14 @@ module PageActions
     click_on 'Watch For Updates'
   end
 
+  def make_page_public
+    find('.check_off_16', text: 'Public').click
+  end
+
+  def make_page_private
+    find('.check_on_16', text: 'Public').click
+  end
+
   def unwatch_page
     click_on 'Watch For Updates'
   end

--- a/test/helpers/integration/page_assertions.rb
+++ b/test/helpers/integration/page_assertions.rb
@@ -40,6 +40,14 @@ module PageAssertions
     assert_selector '#star.star_empty_dark_16'
   end
 
+  def assert_page_public
+    assert_selector '.check_on_16', text: 'Public'
+  end
+
+  def assert_page_private
+    assert_selector '.check_off_16', text: 'Public'
+  end
+
   def assert_page_watched
     assert_selector '#watch_checkbox.check_on_16'
   end

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -27,6 +27,13 @@ class PageSidebarTest < JavascriptIntegrationTest
     assert_page_not_starred
   end
 
+  def test_public
+    make_page_public
+    assert_page_public
+    make_page_private
+    assert_page_private
+  end
+
   def test_share_with_user
     share_page_with users(:red)
     assert_page_users user, users(:red)


### PR DESCRIPTION
The factory for PageHistories for these cases was broken.
class_for_update needs to be a class method.