### PR TITLE
Missed notification for contact request

### DIFF
--- a/app/controllers/people/friend_requests_controller.rb
+++ b/app/controllers/people/friend_requests_controller.rb
@@ -13,9 +13,11 @@ class People::FriendRequestsController < People::BaseController
     if params[:cancel]
       redirect_to entity_url(@user)
     else
-      req = RequestToFriend.create! recipient: @user, created_by: current_user, message: params[:message]
+      req = RequestToFriend.create! recipient: @user, created_by: current_user,
+        message: params[:message]
       if req.valid?
         success req
+        create_notice req
         redirect_to entity_url(@user)
       else
         error
@@ -28,6 +30,12 @@ class People::FriendRequestsController < People::BaseController
     current_user.remove_contact!(@user)
     success
     redirect_to entity_url(@user)
+  end
+
+  private
+
+  def create_notice(request_obj)
+    RequestNotice.create! request_obj
   end
 
 end

--- a/test/functional/people/friend_requests_controller_test.rb
+++ b/test/functional/people/friend_requests_controller_test.rb
@@ -1,0 +1,26 @@
+require_relative '../../test_helper'
+
+class People::FriendRequestsControllerTest < ActionController::TestCase
+
+  fixtures :users
+
+  def test_new_contact_request_notifies_recipient
+    requesting = users(:blue)
+    recipient  = users(:yellow)
+    login_as requesting
+
+    # Stub permission access for current test case
+    def requesting.may?(*args)
+      true
+    end
+
+    assert_difference 'RequestNotice.count', 1 do
+      xhr :post, :create, person_id: recipient.login
+    end
+
+    notice = RequestNotice.last
+    assert_equal recipient.id, notice.user_id
+    assert_equal 'request_to_friend', notice.data[:title]
+  end
+
+end


### PR DESCRIPTION
If the user A requests the user B to be a contact
user B has no notification about it.
So the only way to approve - check the "Requests" tab manually.

Bug: 9675
Link: https://labs.riseup.net/code/issues/9675

---
The problem occurs because the `FriendRequestsController` does not implement `after_filter` for created requests.

Have fixed it by included common module for such functionality.