### PR TITLE
Notifications for group invite are missed

### DIFF
--- a/app/models/notice/request_notice.rb
+++ b/app/models/notice/request_notice.rb
@@ -14,14 +14,17 @@ class RequestNotice < Notice
         super(*args)
       else
         request = args.first
-        if request.recipient.nil?
+        recipient = request.recipient
+
+        if recipient.nil?
           nil
-        elsif request.recipient.is_a? Group
-          request.recipient.users.each do |user|
+        elsif recipient.is_a? Group
+          recipient = recipient.council if recipient.council
+          recipient.users.each do |user|
             create!(request: request, user: user)
           end
         else
-          create!(request: request, user: request.recipient)
+          create!(request: request, user: recipient)
         end
       end
     end

--- a/test/functional/groups/invites_controller_test.rb
+++ b/test/functional/groups/invites_controller_test.rb
@@ -3,11 +3,18 @@ require File.dirname(__FILE__) + '/../../test_helper'
 class Groups::InvitesControllerTest < ActionController::TestCase
 
   def setup
-    @user     = FactoryGirl.create(:user)
-    @group    = FactoryGirl.create(:group)
-    @network  = FactoryGirl.create(:network)
+    @user                          = FactoryGirl.create(:user)
+    @user_not_in_group             = FactoryGirl.create(:user)
+    @user_not_in_network           = FactoryGirl.create(:user)
+    @user_council                  = FactoryGirl.create(:user)
+    @group                         = FactoryGirl.create(:group)
+    @council                       = FactoryGirl.create(:council)
+    @network                       = FactoryGirl.create(:network)
+    @council.add_user! @user_council
     @group.add_user! @user
+    @group.add_user! @user_not_in_network
     @network.add_user! @user
+    @network.add_user! @user_not_in_group
   end
 
 
@@ -63,6 +70,76 @@ class Groups::InvitesControllerTest < ActionController::TestCase
     assert_equal @group, req.requestable
     assert_equal email, req.email
     assert req.valid?
+  end
+
+  def test_invite_to_join_us_notifies_recipient
+    login_as @user
+    recipient = FactoryGirl.create(:user)
+
+    assert_difference 'RequestNotice.count' do
+      post :create, group_id: @group.to_param, recipients: recipient.name
+    end
+
+    notice = RequestNotice.last
+    assert_equal recipient.id, notice.user_id
+    assert_equal 'request_to_join_us', notice.data[:title]
+  end
+
+  def test_invite_to_join_us_notifies_all_valid_recipients
+    login_as @user
+    recipient = FactoryGirl.create(:user)
+
+    # As @user already member of a group it should not be notified
+    assert_difference('RequestNotice.count', 2) do
+      post :create, group_id: @group.to_param,
+        recipients: "#{recipient.name}, #{@user.name}, #{@user_not_in_group.name}"
+    end
+
+    notice = RequestNotice.last(2)
+    assert_equal recipient.id, notice.first.user_id
+    assert_equal @user_not_in_group.id, notice.last.user_id
+    assert_equal 'request_to_join_us', notice.first.data[:title]
+    assert_equal 'request_to_join_us', notice.last.data[:title]
+  end
+
+  def test_invite_group_to_network_notifies_all_group_members_if_no_council
+    login_as @user
+
+    # @group has only two members, no council
+    assert_nil @group.council
+    assert_difference('RequestNotice.count', 2) do
+      post :create, group_id: @network.to_param, recipients: @group.name
+    end
+
+    notice = RequestNotice.last(2)
+    assert_equal @user.id, notice.first.user_id
+    assert_equal @user_not_in_network.id, notice.last.user_id
+    assert_equal 'request_to_join_our_network', notice.first.data[:title]
+    assert_equal 'request_to_join_our_network', notice.last.data[:title]
+  end
+
+  def test_invite_group_to_network_notifies_only_council_if_it_presents
+    login_as @user
+
+    # @group has a council with one member and two other members
+    @group.council = @council
+    @group.save
+    assert_instance_of Council, @group.council
+    assert_difference 'RequestNotice.count' do
+      post :create, group_id: @network.to_param, recipients: @group.name
+    end
+
+    notice = RequestNotice.last
+    assert_equal @user_council.id, notice.user_id
+    assert_equal 'request_to_join_our_network', notice.data[:title]
+  end
+
+  def test_invite_by_email_does_not_notify_internally
+    email =  "test@mail.me"
+    login_as @user
+    assert_no_difference 'RequestNotice.count' do
+      post :create, group_id: @group.to_param, recipients: email
+    end
   end
 
 end

--- a/test/unit/notice/request_notice_test.rb
+++ b/test/unit/notice/request_notice_test.rb
@@ -1,0 +1,43 @@
+require File.dirname(__FILE__) + '/../../test_helper'
+
+class RequestNoticeTest < ActiveSupport::TestCase
+
+  def setup
+    @user_in_network  = FactoryGirl.create(:user)
+    @user_in_group_1  = FactoryGirl.create(:user)
+    @user_in_group_2  = FactoryGirl.create(:user)
+    @user_council     = FactoryGirl.create(:user)
+    @group            = FactoryGirl.create(:group)
+    @council          = FactoryGirl.create(:council)
+    @network          = FactoryGirl.create(:network)
+
+    @group.add_user! @user_in_group_1
+    @group.add_user! @user_in_group_2
+    @council.add_user! @user_council
+    @network.add_user! @user_in_network
+  end
+
+
+  def test_request_for_group_without_council_notifies_all_members
+    req = RequestToJoinOurNetwork.create(created_by: @user_in_network,
+      recipient: @group, requestable: @network)
+
+    assert_nil @group.council
+    assert_difference('RequestNotice.count', 2) do
+      RequestNotice.create! req
+    end
+  end
+
+  def test_request_for_group_with_council_notifies_only_council_members
+    req = RequestToJoinOurNetwork.create(created_by: @user_in_network,
+      recipient: @group, requestable: @network)
+
+    @group.council = @council
+    @group.save
+    assert_instance_of Council, @group.council
+    assert_difference 'RequestNotice.count' do
+      RequestNotice.create! req
+    end
+  end
+
+end


### PR DESCRIPTION
Currently we have no notifications for such use-cases:
- group member invites new users to a group
- network group invites the group to join it

Bug: 9676
Link: https://labs.riseup.net/code/issues/9676