### PR TITLE
Exception: Translation missed for network group invite notification

### DIFF
--- a/config/en.yml
+++ b/config/en.yml
@@ -166,11 +166,14 @@ en:
 ########################################
 ### en/exceptions.yml
   exception:
-    not_found: Not Found
     title:
-      not_found: Not Found
+      not_found: "%{thing} Not Found"
+      group:
+        not_found: Group Not Found
     description:
       not_found: Sorry, we could not find what you were looking for.
+      group:
+        not_found: Sorry, we could not find the group you were looking for.
 
 
 ########################################
@@ -314,6 +317,7 @@ en:
   messages: Messages
   page: Page
   tags: Tags
+  tasks: Tasks
   title: Title
   body: Body
   text_message: Text Message
@@ -808,6 +812,9 @@ en:
   request_to_friend_short: Shall %{user} become a contact of %{other_user}?
   request_to_friend_description: User %{user} has requested to become a contact of user
     %{other_user}.
+  request_to_join_our_network:
+    one: Invitation to Join
+    other: Invitations to Join
   request_to_destroy_our_group: Request to Destroy Group
   request_to_join_our_network_short: Shall %{group} join %{network}?
   request_to_join_our_network_description: The group %{group} was invited to join then

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -591,6 +591,9 @@ de:
   request_to_friend: Kontaktanfrage stellen
   request_to_friend_short: Soll %{user} ein Kontakt von %{other_user} werden?
   request_to_friend_description: '%{user} würde %{other_user} gerne zu seinen_ihren Kontakten hinzufügen'
+  request_to_join_our_network:
+    one: Einladung beizutreten
+    other: Einladungen beizutreten
   request_to_destroy_our_group: Anfrage Gruppe zu vernichten
   request_to_join_our_network_short: Soll %{group} dem Netzwerk %{network} beitreten?
   request_to_join_our_network_description: Gruppe %{group} wurde eingeladen, sich dem Netzwerk %{network} anzuschließen

--- a/config/locales/en/requests.yml
+++ b/config/locales/en/requests.yml
@@ -38,6 +38,9 @@ en:
   request_to_friend: "Request to Become Contacts"
   request_to_friend_short: "Shall %{user} become a contact of %{other_user}?"
   request_to_friend_description: "User %{user} has requested to become a contact of user %{other_user}."
+  request_to_join_our_network:
+    one: "Invitation to Join"
+    other: "Invitations to Join"
 
   request_to_destroy_our_group: "Request to Destroy Group"
   request_to_join_our_network_short: "Shall %{group} join %{network}?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -604,6 +604,9 @@ fr:
   request_to_friend: Demander à être en contact
   request_to_friend_short: '%{user} peut-il ou peut-elle être mise en contact avec %{other_user} ?'
   request_to_friend_description: '%{user} aimerait être en contact avec %{other_user}'
+  request_to_join_our_network:
+    one: Invitation à adhérer
+    other: Invitations à adhérer
   request_to_destroy_our_group: Demander à détruire le groupe
   request_to_join_our_network_short: '%{group} peut-il rejoindre %{network} ?'
   request_to_join_our_network_description: Le groupe %{group} a été invité à rejoindre le réseau %{network}.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -599,6 +599,9 @@ it:
   request_to_friend: Richiesta di Diventare Contatti
   request_to_friend_short: '%{user} deve diventare contatto di %{other_user}?'
   request_to_friend_description: '%{user} vorrebbe essere il contatto di %{other_user}'
+  request_to_join_our_network:
+    one: Invito ad entrare a fare parte
+    other: Inviti ad entrare a fare parte
   request_to_destroy_our_group: Richiesta di Distruggere Gruppo
   request_to_join_our_network_short: '%{group} deve unirsi alla rete %{network}?'
   request_to_join_our_network_description: il gruppo %{group} è stato inviato a entrare nella rete %{network}

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -605,6 +605,9 @@ nl:
   request_to_friend: Aanvraag contacten te worden
   request_to_friend_short: Zal %{user} een contact van %{other_user} worden?
   request_to_friend_description: Gebruiker / Gebruikster %{user} heeft een aanvraag gesteld een contact van gebruiker / gebruikster user %{other_user} te worden.
+  request_to_join_our_network:
+    one: Invitatie om bijtetreden
+    other: Invitaties om bijtetreden
   request_to_destroy_our_group: Aanvrag om groep de verwoesten
   request_to_join_our_network_short: Zal %{group} %{network} bijtreden?
   request_to_join_our_network_description: De groep %{group} was geïnviteerd de netwerk %{network} bijtetreden.

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -595,6 +595,9 @@
   request_to_friend: Be om å bli kontakter
   request_to_friend_short: Skal %{user} bli %{other_user} sin kontakt?
   request_to_friend_description: Bruker %{user} har bedt om å bli %{other_user} sin kontakt.
+  request_to_join_our_network:
+    one: Invitasjon til å bli medlem
+    other: Invitasjoner til å bli medlem
   request_to_destroy_our_group: Forespørsel om å destruere gruppe
   request_to_join_our_network_short: Skal %{group} bli medlem av %{network}?
   request_to_join_our_network_description: Gruppa %{group} ble invitert til å bli medlem i nettverket %{network}.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -617,6 +617,10 @@ pl:
   request_to_friend: Wyślij zaproszenie do kontaktów
   request_to_friend_short: Czy dodać %{user} do kontaktów %{other_user}?
   request_to_friend_description: '%{user} chce zostać dodana/y do kontaktów %{other_user}'
+  request_to_join_our_network:
+    one: Zaproszenie do dołączenia
+    few: Zaproszenia do dołączenia
+    other: Zaproszenia do dołączenia
   request_to_destroy_our_group: Poproś o skasowanie grupy
   request_to_join_our_network_short: Czy %{group} ma dołączyć do %{network}?
   request_to_join_our_network_description: Grupa %{group} została zaproszona do sieci %{network}

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -601,6 +601,9 @@ pt:
       request_to_create_council: Pedir para Criar um Conselho
       request_to_remove_user: Pedir para Remover um Membro
   request_to_friend: Pedir para se Tornarem Contatos
+  request_to_join_our_network:
+    one: Convite para Participar
+    other: Convites para Participar
   request_to_friend_short: Será que %{user} poderia se tornar contato de %{other_user}?
   request_to_friend_description: '%{user} gostaria de ser contato de %{other_user}'
   request_to_destroy_our_group: Pedir para Destruir o Grupo

--- a/lib/dummystrings.rb
+++ b/lib/dummystrings.rb
@@ -7,12 +7,7 @@
 # requests:
 
 :request_to_destroy_our_group.t
-:request_to_friend.t
-:request_to_join_our_network.t
-:request_to_join_us.t
 :request_to_join_us_via_email.t
-:request_to_join_you.t
-:request_to_join_your_network.t
 :request_to_remove_user.t
 :votable_request.t
 


### PR DESCRIPTION
When I invite a group A to join the network B, the members from this group A,
see an exception on `/me` page.

The exception description notices:
```ruby
I18n::MissingTranslationData: translation missing: en.request_to_join_our_network
```
It occurs because of the notification constructed for user with info about request to join network.

This issue related to the fixed issue [There is no notification for invite to join group](https://labs.riseup.net/code/issues/9676) / PR https://github.com/riseuplabs/crabgrass-core/pull/255, because before we have no such notifications at all..

So need to be tested only after [#9676](https://github.com/riseuplabs/crabgrass-core/pull/255) would be resolved and merged.

Bug: 9686
Link: https://labs.riseup.net/code/issues/9686