### PR TITLE
Feature: Ability to remove account settings avatar

### DIFF
--- a/app/controllers/me/avatars_controller.rb
+++ b/app/controllers/me/avatars_controller.rb
@@ -5,6 +5,17 @@ class Me::AvatarsController < Me::BaseController
   before_filter :setup
   cache_sweeper :user_sweeper
 
+  def destroy
+    if avatar = @entity.avatar
+      expire_avatar(avatar)
+      avatar.destroy
+      @entity.avatar = nil
+      @entity.increment!(:version)
+    end
+  ensure
+    redirect_to @success_url
+  end
+
   protected
 
   def setup

--- a/app/helpers/common/ui/avatar_helper.rb
+++ b/app/helpers/common/ui/avatar_helper.rb
@@ -68,6 +68,11 @@ module Common::Ui::AvatarHelper
       { class: 'inline' }
   end
 
+  def remove_image_link(entity)
+    link_to :remove_image_link.t, me_avatar_path(entity), method: :delete,
+      icon: 'trash', class: 'inline', confirm: :confirm_image_delete.t
+  end
+
   def edit_avatar_path(entity)
     if entity == current_user
       edit_me_avatar_path

--- a/app/views/me/settings/show.html.haml
+++ b/app/views/me/settings/show.html.haml
@@ -16,6 +16,7 @@
     - f.row do |r|
       - r.label :icon.t
       - r.input avatar_field(current_user)
+      - r.input remove_image_link(current_user) if current_user.avatar
     - f.label :notification.t
     - f.row do |r|
       - r.label :email.t
@@ -23,9 +24,9 @@
     - f.row do |r|
       - r.label :notice.t
       - r.info :do_you_want_to_receive_email_notifications.t
-      - r.input select 'user', 'receive_notifications', 
-        [ [I18n.t('notification_select.none'), ""], 
-          [I18n.t('notification_select.single'), "Single"], 
+      - r.input select 'user', 'receive_notifications',
+        [ [I18n.t('notification_select.none'), ""],
+          [I18n.t('notification_select.single'), "Single"],
           [I18n.t('notification_select.digest'), "Digest"] ],
         {}, class: 'form-control'
     - f.label :locale.t

--- a/config/locales/en/me.yml
+++ b/config/locales/en/me.yml
@@ -37,7 +37,7 @@ en:
   select_image_file: "select image file"
   or_image_url: "or image URL"
   upload_image_link: "upload image"
-  ##!  remove_image_link: "remove image"
+  remove_image_link: "remove image"
   ##!  copy_paste_option_name: "Copy and paste the name of the option(s) to be customized into the box below (one option per line)."
   ##!  click_on: "Click on"
   ##!  view_custom_names: "to view the custom appearance option names."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Crabgrass::Application.routes.draw do
     resource  :profile, controller: 'profile', only: [:edit, :update]
     resources :requests, only: [:index, :update, :destroy, :show]
     # resources :events, only: [:index]
-    resource :avatar, only: [:create, :edit, :update]
+    resource :avatar, only: [:create, :edit, :update, :destroy]
     resources :tasks, only: [:index]
   end
 

--- a/test/functional/me/avatars_controller_test.rb
+++ b/test/functional/me/avatars_controller_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class Me::AvatarsControllerTest < ActionController::TestCase
+
+  def setup
+    @user  = FactoryGirl.create(:user)
+  end
+
+  def test_user_could_upload_avatar_from_file
+    login_as @user
+    assert_nil @user.avatar
+    user_uploads_avatar
+
+    assert_redirected_to me_settings_url
+    assert_instance_of Avatar, @user.avatar
+  end
+
+  def test_user_could_remove_uploaded_avatar
+    login_as @user
+    user_uploads_avatar
+    assert_not_nil @user.avatar
+
+    delete :destroy
+
+    assert_redirected_to me_settings_url
+    assert_nil @user.avatar
+  end
+
+  private
+
+  def user_uploads_avatar
+    file_path = File.join('files', 'photo.jpg')
+    file = fixture_file_upload(file_path, 'image/jpeg')
+
+    post :create, avatar: { image_file: file, image_file_url: '' }
+  end
+
+end


### PR DESCRIPTION
Currently there is no way to remove the image
for avatar placed at `me/settings` section.
We can only replace it with another one.

This patch implements the possibility to completely
remove old avatar and have the the default icon come back.

Feature: 3292
Link: https://labs.riseup.net/code/issues/3292

Example how it looks like:
![remove_avatar_workflow](https://cloud.githubusercontent.com/assets/526022/8513741/e940b686-237f-11e5-8cb4-84bea37b0c48.png)