### PR TITLE
fix: canceling wiki edits renders wiki

### DIFF
--- a/extensions/pages/wiki_page/test/integration/wiki_test.rb
+++ b/extensions/pages/wiki_page/test/integration/wiki_test.rb
@@ -19,6 +19,12 @@ class WikiTest < JavascriptIntegrationTest
     assert_success "Changes saved"
   end
 
+  def test_cancel_edit
+    assert_page_tab "Edit"
+    click_button 'Cancel'
+    assert_page_tab "Show"
+  end
+
   def test_format_help
     find('.edit_wiki').click_on 'Editing Help'
     help = windows.last

--- a/test/functional/wikis/wikis_controller_test.rb
+++ b/test/functional/wikis/wikis_controller_test.rb
@@ -63,6 +63,21 @@ class Wikis::WikisControllerTest < ActionController::TestCase
     assert_equal @user.login, @wiki.page.updated_by_login
   end
 
+  def test_cancel_update
+    @wiki = create_page_wiki
+    login_as @user
+    former = @wiki.body_html
+    assert_permission :may_edit_wiki? do
+      xhr :post, :update,
+        id: @wiki.id,
+        wiki: {body: '*updated*', version: 1},
+        cancel: true
+    end
+    assert_equal former, @wiki.reload.body_html
+    assert !(@user.login == @wiki.page.updated_by_login),
+      'cancel should not set updated_by'
+  end
+
   def test_show_private_group_wiki
     @wiki = create_profile_wiki(true)
     login_as @user


### PR DESCRIPTION
Looks like before filters use a different set of formats for render.
They seem to default to html while the action itself would render js
just fine.

So cancel and submit without save buttons will be handled in #update
again. This way i don't have to worry about picking the right formatn.