### PR TITLE
Feature: Add "Send Message" link to a user profile

### DIFF
--- a/app/helpers/people/base_helper.rb
+++ b/app/helpers/people/base_helper.rb
@@ -20,4 +20,9 @@ module People::BaseHelper
     end
   end
 
+  def profile_send_message_link
+    if may_pester?
+      link_to :send_message_link.t, me_discussion_posts_path(@user), icon: :page_message
+    end
+  end
 end

--- a/app/permissions/people_permission.rb
+++ b/app/permissions/people_permission.rb
@@ -23,4 +23,8 @@ module PeoplePermission
     current_user.friend_of?(@user)
   end
 
+  def may_pester?
+    current_user.may?(:pester, @user) && current_user != @user
+  end
+
 end

--- a/app/views/people/home/_sidebox.html.haml
+++ b/app/views/people/home/_sidebox.html.haml
@@ -40,3 +40,5 @@
 
 %hr
 = profile_contact_link
+%br
+= profile_send_message_link


### PR DESCRIPTION
Hi!
Here is small feature implementation requested by WhilelM: ["Send message’ link from someone’s profil"](https://we.riseup.net/riseup+crabgrass/test-new-version-of-crabgrass#missing-features)

Description:
As user A who has rights to send a message to user B,
the link 'Send Message' should be displayed at user B profile page.

Placed under left side-bar, click leads to a new or existent discussion
page with selected user.

![send_message](https://cloud.githubusercontent.com/assets/526022/8630356/305cea76-276d-11e5-9a18-1058c3af4d08.png)

Have not added tests for it because permissions are already tested as part of `user_permission_test.rb` and I've wanted to minimize code duplication.

Seems that it would be good to create a `feature` in the labs tracker, or it is not necessary?