### PR TITLE
Delete private message action does not hide it

### DIFF
--- a/app/controllers/common/posts.rb
+++ b/app/controllers/common/posts.rb
@@ -31,7 +31,7 @@ module Common::Posts
   def destroy
     @post.destroy
     render :update do |page|
-      page.hide @post.dom_id
+      page.hide dom_id(@post)
     end
   end
 

--- a/lib/extends/active_record.rb
+++ b/lib/extends/active_record.rb
@@ -63,10 +63,6 @@ ActiveRecord::Base.class_eval do
     end
   end
 
-  def dom_id
-    [self.class.name.downcase.pluralize.dasherize, id] * '-'
-  end
-
   # make sanitize_sql public so we can use it ourselves
   def self.quote_sql(condition)
     sanitize_sql_array(condition)

--- a/test/integration/message_test.rb
+++ b/test/integration/message_test.rb
@@ -32,13 +32,34 @@ class MessageTest < JavascriptIntegrationTest
     assert_no_content msg
   end
 
+  def test_delete_message
+    text = "Here is my Message"
+    blue = users(:blue)
+    red = users(:red)
+    login blue
+    new_msg = blue.send_message_to!(red, text, nil)
+    msg_id = "#private_post_#{new_msg.id}"
+
+    visit "/me/messages/#{red.login}/posts"
+
+    assert_selector msg_id
+
+    hover_and_edit(text) do
+      click_on 'Delete'
+      wait_for_ajax
+    end
+
+    assert_no_selector msg_id
+  end
+
+  private
+
   def send_message(msg, options = {})
     click_on 'Messages'
     fill_in 'Recipient', with: options[:to]
     fill_in 'Message', with: msg
     click_on 'Send'
   end
-
 
 end
 


### PR DESCRIPTION
Fix for issue when user can not see the result of delete
action on private message until page reload.

It leads to exception if user would try to click the 'Delete'
button second time.

Issue: 9724
Link: https://labs.riseup.net/code/issues/9724

---
Changed hand-written AR method call into AS helper.
Actually AR method have formatted record into wrong selector. That is the reason why I have deleted it :sunglasses:
Of course I have checked that it used nowhere besides changed controller..