### PR TITLE
Anchor links for comments

### DIFF
--- a/app/helpers/common/ui/post_helper.rb
+++ b/app/helpers/common/ui/post_helper.rb
@@ -1,11 +1,25 @@
 module Common::Ui::PostHelper
 
-  def created_modified_date(created, modified=nil)
-    return friendly_date(created) unless modified and (modified > created + 30.minutes)
+  def created_date(created, modified=nil, href=nil)
+    created_date = friendly_date(created)
+    link_to_function created_date,
+      'var parent = this.up("div");
+       parent.toggleClassName("hide");
+       parent.siblings().last().toggleClassName("hide")',
+      href: href, class: 'dotted'
+  end
+
+  def created_modified_date(created, modified=nil, href=nil)
+    return created_date(created, modified, href) unless modified and (modified > created + 30.minutes)
     created_date = friendly_date(created)
     modified_date = friendly_date(modified)
-    detail_string = "created:&nbsp;#{created_date}<br/>modified:&nbsp;#{modified_date}"
-    link_to_function created_date, %Q[this.replace("#{detail_string}")], class: 'dotted'
+    detail_string = "created:&nbsp;#{created_date}<br>modified:&nbsp;#{modified_date}"
+
+    link_to_function detail_string.html_safe,
+      'var parent = this.up("div");
+       parent.toggleClassName("hide");
+       parent.siblings().last().toggleClassName("hide")',
+      href: href, class: 'dotted'
   end
 
   #

--- a/app/views/common/posts/default/_row.html.haml
+++ b/app/views/common/posts/default/_row.html.haml
@@ -14,7 +14,10 @@
     %td.post_author
       %div.author{style: author_style}
         %div.username= link_to_user post.user
-        %div.nowrap.date= created_modified_date(post.created_at, post.updated_at)
+        %div.nowrap.date.created-link
+          = created_date(post.created_at, post.updated_at, "#post-#{post.id}")
+        %div.nowrap.date.hide.detailed-link
+          = created_modified_date(post.created_at, post.updated_at, "#post-#{post.id}")
     %td.post_body.shy_parent{stars_for(post)}
       = render partial: 'common/posts/default/body', locals: local_assigns
   %tr.post_spacer_bottom


### PR DESCRIPTION
Here is fix for one issue, related to comment date link and small feature implementation.

**Issue**: if we edit a comment that we own its date time becomes a link
that supposed show real time created/modification on click.
This functionality doesn't work at all, leads to javascript error in browser console.

**Feature**: now if I want to point somebody on some specific comment I could only note
the page where it is posted, but after user should go though all of the comments to find an appropriate.

It is not comfortable and decreases quoting possibilities if we want
share links to comments on external resources.

So I think that it might be useful.

Issue: #9729
Link: https://labs.riseup.net/code/issues/9729

![anchor_links](https://cloud.githubusercontent.com/assets/526022/8638236/6350a6e2-28bd-11e5-8382-4bf18d329f94.gif)

Now each comment has anchor link ex. `http://xxxx/blue/multiply+1008#post-312` and could be easily mentioned in discussions (not only inside platform).