### PR TITLE
bugfix: duplicate use of section names broke wiki

### DIFF
--- a/vendor/gems/riseuplabs-greencloth-0.1/lib/green_tree.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/lib/green_tree.rb
@@ -244,30 +244,41 @@ class GreenTree < Array
   # some transformed text, that we then need to match against original text.
   # yep, it is that ugly.
   def markup_regexp
-    # take out carriage returns
-    heading_text = Regexp.escape(self.text.gsub(/\r\n/, "\n"))
-
-    # look for the words - but allow special chars in between
-    heading_text = heading_text.gsub(/\\\s/, '[\W_](.*[\W_])?')
-    # remove html entities, and let them match one to several characters
-    heading_text.gsub!(/&(\w{2,6}?|\\#[0-9A-Fa-f]{2,6});/,'.{1,3}')
-
-    # add back carriage returns as optional
-    heading_text.gsub!('\\n', '\\r?\\n')
-
-
-    Regexp.union(
-      /^
-      [^\n]*#{heading_text}[^\n]*\s*
-      \n[=-]+\s*?(\r?\n\r?\n?|$)
-      /x,
-      /^
-      h#{heading_level}\.\s+
-      [^\n]*#{heading_text}[^\n]*
-      \s*?(\r?\n\r?\n?|$)
-      /x
-    )
+    if heading_level > 2
+      heading_level_regexp
+    else
+      Regexp.union heading_level_regexp, heading_underline_regexp
+    end
   end
 
+  protected
+
+  def regexp_text
+    @regexp_text ||=
+    # take out carriage returns
+    Regexp.escape(self.text.gsub(/\r\n/, "\n")).
+      # look for the words - but allow special chars in between
+      gsub(/\\\s/, '[\W_](.*[\W_])?').
+      # remove html entities, and let them match one to several characters
+      gsub(/&(\w{2,6}?|\\#[0-9A-Fa-f]{2,6});/,'.{1,3}').
+      # add back carriage returns as optional
+      gsub('\\n', '\\r?\\n')
+  end
+
+  def heading_underline_regexp
+    underline = (heading_level == 1) ? '=' : '-'
+    /^
+    [^\n]*#{regexp_text}[^\n]*\s*
+    \n#{underline}+\s*?(\r?\n\r?\n?|$)
+    /x
+  end
+
+  def heading_level_regexp
+    /^
+    h#{heading_level}\.\s+
+    [^\n]*#{regexp_text}[^\n]*
+    \s*?(\r?\n\r?\n?|$)
+    /x
+  end
 end
 

--- a/vendor/gems/riseuplabs-greencloth-0.1/test/fixtures/sections.yml
+++ b/vendor/gems/riseuplabs-greencloth-0.1/test/fixtures/sections.yml
@@ -2,7 +2,7 @@
 name: one section no heading
 in: |-
   start unheaded section
-  
+
   line line line
 out: |-
   <div class="wiki_section" id="wiki_section-0">
@@ -23,14 +23,14 @@ out: |-
 ---
 name: some mixed style sections
 in: |-
-  
+
   h2. first section
-  
+
   some blahs
-  
+
   second section
   ==============
-  
+
   more lalas
 out: |-
   <div class="wiki_section" id="wiki_section-0">
@@ -46,11 +46,11 @@ name: section without heading
 in: |-
   some text
   one more line of text without a heading
-  
+
   some blahs
-  
+
   h1. first section heading here
-  
+
   more lalas
 out: |-
   <div class="wiki_section" id="wiki_section-0">
@@ -69,21 +69,21 @@ in: |-
   -----------
   section one line one is here
   section one line two is next
-  
+
   Here is section one still
-  
+
   Section Two
   ==========
   Section two first line
   Section two another line
-  
-  
+
+
   h2. Section 3 with h2
-  
+
   One more line for section 3
-  
+
   h3. final section 4
-  
+
   section 4 first non-blank line
 out: |-
   <div class="wiki_section" id="wiki_section-0">
@@ -106,3 +106,23 @@ out: |-
     <h3>final section 4</h3>
     <p>section 4 first non-blank line</p>
   </div>
+name: broken in production
+in: |-
+  [[toc]]
+
+  Me Section
+  ---------------------
+
+  h3. Me Section
+
+  text
+out: |-
+  <ul class="toc">
+  <li class="toc1"><a href="#me-section"><span>1</span> Me Section</a></li>
+  <ul>
+  <li class="toc2"><a href="#me-section_2"><span>1.1</span> Me Section</a></li>
+  </ul>
+  </ul>
+  <h2 class="first">Me Section</h2>
+  <h3>Me Section</h3>
+  <p>text</p>

--- a/vendor/gems/riseuplabs-greencloth-0.1/test/markup_test.rb
+++ b/vendor/gems/riseuplabs-greencloth-0.1/test/markup_test.rb
@@ -28,7 +28,7 @@ class TestMarkup < MiniTest::Test
         raise
       end
     end
-    @special = ['sections.yml', 'outline.yml']
+    @special = ['outline.yml']
     @markup_fixtures = @fixtures.reject{|key,value| @special.include? key}
   end
 


### PR DESCRIPTION
A wiki with the same section names nested inside each other broke
redcloth because the heading regexp was to loose.

We do a depth first search for headings. Looking for the nested heading would then pick the parent heading with the old regexp. In particular we always searched for underlined headings even if the heading level was higher than 2 and no underlines were possible. We also searched for underlines with '==' and '--' no matter if the heading was an h1 or and h2.

This is now fixed so that only the proper underlines will match.