### PR TITLE
bugfix: fix 500 when approving RequestToRemoveUser

### DIFF
--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -278,6 +278,7 @@ class Request < ActiveRecord::Base
   ##
 
   def event() end
+  def event_attrs(); {}; end
   def description() end
   def short_description() end
   def votable?() false end

--- a/test/functional/groups/membership_requests_controller_test.rb
+++ b/test/functional/groups/membership_requests_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Groups::MembershipRequestsControllerTest < ActionController::TestCase
+
+  def setup
+    @user  = FactoryGirl.create(:user)
+    @group  = FactoryGirl.create(:group)
+    @group.add_user! @user
+    login_as @user
+  end
+
+  def test_approve
+    @other = FactoryGirl.create(:user)
+    @remove_me = FactoryGirl.create(:user)
+    @group.add_user! @other
+    @group.add_user! @remove_me
+
+    @req = RequestToRemoveUser.create! group: @group,
+      user: @remove_me,
+      created_by: @other
+
+    assert_difference '@group.users.count', -1 do
+      post :update, group_id: @group.to_param, id: @req.id, mark: :approve
+    end
+    assert_response :success
+  end
+end


### PR DESCRIPTION
it lacked the event_attrs. We now define them for Request base class.