### PR TITLE
try converting first page of pdf only

### DIFF
--- a/test/unit/assets/pdf_test.rb
+++ b/test/unit/assets/pdf_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Assets
+  class PdfTest < ActiveSupport::TestCase
+
+    def setup
+      setup_assets
+    end
+
+    def teardown
+      teardown_assets
+    end
+
+    def test_pdf_upload
+      @asset = Asset.create_from_params uploaded_data: upload_data('test.pdf')
+      @asset.generate_thumbnails
+      @asset.thumbnails.each do |thumb|
+        assert thumb.ok?, 'generating thumbnail "%s" should have succeeded' % thumb.name
+        assert thumb.private_filename, 'thumbnail "%s" should exist' % thumb.name
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
It's way faster for large documents. If it fails we retry without setting the page.

You can use filename.pdf[0] in gm convert to only convert the first
page. This speeds up dealing with large documents a lot.
(.5 sec instead of 18 sec. for a 80 page, 7MB pdf i tried).

Rumors have it that some documents use letters for indexing their pages
and [0] won't work. So we need a fallback.