### PR TITLE
performance: create small jpgs from large ones

### DIFF
--- a/app/models/assets/doc_asset.rb
+++ b/app/models/assets/doc_asset.rb
@@ -17,9 +17,9 @@ class DocAsset < Asset
 
   define_thumbnails(
     pdf: {ext: 'pdf', remote: true},
-    small: {size: '64x64>',   ext: 'jpg', title: 'Small Thumbnail'},
-    medium: {size: '200x200>', ext: 'jpg', title: 'Medium Thumbnail'},
-    large: {size: '500x500>', ext: 'jpg', title: 'Large Thumbnail'}
+    large: {size: '500x500>', ext: 'jpg', title: 'Large Thumbnail'},
+    medium: {size: '200x200>', ext: 'jpg', depends: :large, title: 'Medium Thumbnail'},
+    small: {size: '64x64>',   ext: 'jpg', depends: :large, title: 'Small Thumbnail'}
   )
 
 end

--- a/app/models/assets/image_asset.rb
+++ b/app/models/assets/image_asset.rb
@@ -5,9 +5,9 @@ class ImageAsset < Asset
   end
 
   define_thumbnails(
-    small: {size: '64x64>',   ext: 'jpg', title: 'Small Thumbnail'},
-    medium: {size: '200x200>', ext: 'jpg', title: 'Medium Thumbnail'},
-    large: {size: '500x500>', ext: 'jpg', title: 'Large Thumbnail'}
+    large: {size: '500x500>', ext: 'jpg', title: 'Large Thumbnail'},
+    medium: {size: '200x200>', ext: 'jpg', depends: :large, title: 'Medium Thumbnail'},
+    small: {size: '64x64>',   ext: 'jpg', depends: :large, title: 'Small Thumbnail'}
   )
 
 end

--- a/app/models/assets/spreadsheet_asset.rb
+++ b/app/models/assets/spreadsheet_asset.rb
@@ -8,9 +8,9 @@ class SpreadsheetAsset < Asset
     ods: {ext: 'ods', remote: true},
     csv: {ext: 'csv', remote: true},
     pdf: {ext: 'pdf', remote: true},
-    small: {size: '64x64>',   ext: 'jpg', depends: :pdf, title: 'Small Thumbnail'},
-    medium: {size: '200x200>', ext: 'jpg', depends: :pdf, title: 'Medium Thumbnail'},
-    large: {size: '500x500>', ext: 'jpg', depends: :pdf, title: 'Large Thumbnail'}
+    large: {size: '500x500>', ext: 'jpg', depends: :pdf, title: 'Large Thumbnail'},
+    medium: {size: '200x200>', ext: 'jpg', depends: :large, title: 'Medium Thumbnail'},
+    small: {size: '64x64>',   ext: 'jpg', depends: :large, title: 'Small Thumbnail'}
   )
 
 end

--- a/app/models/assets/svg_asset.rb
+++ b/app/models/assets/svg_asset.rb
@@ -6,9 +6,9 @@ class SvgAsset < Asset
 
   define_thumbnails(
     rasterized: {ext: 'png', title: "Rasterized", remote: true},
-    small: {size: '64x64>',   ext: 'jpg', depends: :rasterized, title: 'Small Thumbnail'},
-    medium: {size: '200x200>', ext: 'jpg', depends: :rasterized, title: 'Medium Thumbnail'},
-    large: {size: '500x500>', ext: 'jpg', depends: :rasterized, title: 'Large Thumbnail'}
+    large: {size: '500x500>', ext: 'jpg', depends: :rasterized, title: 'Large Thumbnail'},
+    medium: {size: '200x200>', ext: 'jpg', depends: :large, title: 'Medium Thumbnail'},
+    small: {size: '64x64>',   ext: 'jpg', depends: :large, title: 'Small Thumbnail'}
   )
 
 end

--- a/app/models/assets/text_asset.rb
+++ b/app/models/assets/text_asset.rb
@@ -12,9 +12,9 @@ class TextAsset < Asset
     txt: {ext: 'txt', remote: true},
     odt: {ext: 'odt', remote: true},
     pdf: {ext: 'pdf', remote: true},
-    small: {size: '64x64>',   ext: 'jpg', depends: :pdf, title: 'Small Thumbnail'},
-    medium: {size: '200x200>', ext: 'jpg', depends: :pdf, title: 'Medium Thumbnail'},
-    large: {size: '500x500>', ext: 'jpg', depends: :pdf, title: 'Large Thumbnail'}
+    large: {size: '500x500>', ext: 'jpg', depends: :pdf, title: 'Large Thumbnail'},
+    medium: {size: '200x200>', ext: 'jpg', depends: :large, title: 'Medium Thumbnail'},
+    small: {size: '64x64>',   ext: 'jpg', depends: :large, title: 'Small Thumbnail'}
   )
 
 end

--- a/vendor/crabgrass_plugins/crabgrass_media/lib/media/transmogrifier.rb
+++ b/vendor/crabgrass_plugins/crabgrass_media/lib/media/transmogrifier.rb
@@ -176,6 +176,7 @@ module Media
       # run the command
       cmdstr = command_string(*args)
       self.command_output = ""
+      before = Time.now
       IO.popen(cmdstr + ' 2>&1', 'r') do |pipe|
         while line = pipe.gets
           if block_given?
@@ -184,6 +185,7 @@ module Media
           self.command_output << line << "\n"
         end
       end
+      took = Time.now - before
 
       # set the status
       status = case $?.exitstatus
@@ -194,6 +196,7 @@ module Media
       end
       if status == :success
         log_command cmdstr
+        log_command "took #{took} seconds."
       else
         log_error cmdstr
         msg = 'exited with "%s"' % $?.exitstatus

--- a/vendor/crabgrass_plugins/crabgrass_media/transmogrifiers/graphicsmagick.rb
+++ b/vendor/crabgrass_plugins/crabgrass_media/transmogrifiers/graphicsmagick.rb
@@ -80,7 +80,14 @@ class GraphicsMagickTransmogrifier < Media::Transmogrifier
     run_command(*arguments, &block)
   end
 
+  # try to detect the dimensions of the first page.
+  # fallback to detecting dimensions of all pages.
   def dimensions(filename)
+    run_dimensions(filename.to_s + '[0]') ||
+      run_dimensions(filename.to_s)
+  end
+
+  def run_dimensions(filename)
     if available?
       args = [gm_command, 'identify', '-format', '%m %w %h', filename]
       dimensions = nil


### PR DESCRIPTION
For a single page super simple pdf that is about 8 times faster.
For a larger more complex one it's 20 times faster.

Also only look at the 0th page to determine page size. Huge speedup for
large pdfs. (15 sec -> 0.7 sec) for 80 page pdf.