### PR TITLE
responsive attachment images in sidebar

### DIFF
--- a/app/helpers/common/ui/image_helper.rb
+++ b/app/helpers/common/ui/image_helper.rb
@@ -226,7 +226,6 @@ module Common::Ui::ImageHelper
     link_to img, url, class: klass, title: asset.filename, style: style, method: method
   end
 
-
   def thumbnail_or_icon(asset, thumbnail, width=nil, height=nil, html_options={})
     if thumbnail
       image_tag(thumbnail.url, html_options)

--- a/app/helpers/pages/sidebar_helper.rb
+++ b/app/helpers/pages/sidebar_helper.rb
@@ -148,7 +148,13 @@ module Pages::SidebarHelper
   def page_attachments
     if @page.assets.any?
       safe_join @page.assets.collect { |asset|
-        link_to_asset(asset, :small, :crop! => '36x36')
+        thumbnail = asset.thumbnail(:medium)
+        if thumbnail
+          image = image_tag(thumbnail.url)
+        else
+          image = icon_for(asset) + asset.filename
+        end
+        link_to image, asset.url, class: "attachment", title: asset.filename
       }
     elsif may_edit_page?
       ''

--- a/app/stylesheets/pages/_sidebar.scss
+++ b/app/stylesheets/pages/_sidebar.scss
@@ -50,6 +50,33 @@
   overflow: auto;
 }
 
+/*
+  Responsive Attachments in the Sidebar
+
+  On xs screens display 1 image per row. 2 on small to medium and 3 on large.
+  In order to prevent the next image being put under the last image in the
+  previous row if that image is a bit smaller we fix the height of a.attachment
+  This way the image will scale inside but the container will always have the
+  same height.
+  We do not apply this for xs screens as it's not needed with 1 image per row.
+*/
+#page_sidebar .attachments {
+  @include make-row;
+  a.attachment {
+    @include make-xs-column(6);
+    @include make-lg-column(4);
+    height: 64px;
+    @media (min-width: $screen-sm-min) {
+      height: 100px;
+    }
+    overflow: hidden;
+    padding: 10px;
+    img {
+      max-width: 100%;
+    }
+  }
+}
+
 ul.side_list {
   @include list-unstyled;
   clear: both;

--- a/test/helpers/integration/javascript/ajax_pending.rb
+++ b/test/helpers/integration/javascript/ajax_pending.rb
@@ -19,8 +19,8 @@ module AjaxPending
     end
 
     def message
-      urls = @reqs.map(&:url).to_sentence
-      "The ajax request to #{urls} was not answered during the test."
+      req = @reqs.last
+      "The #{req.method} request to #{req.url} was not answered during the test."
     end
   end
 

--- a/test/helpers/integration/javascript/page_actions.rb
+++ b/test/helpers/integration/javascript/page_actions.rb
@@ -103,8 +103,8 @@ module PageActions
 
   # verify that the little thumbnail image actually gets displayed
   def check_attachment_thumbnail
-    find("#attachments a.thumbnail img").synchronize do
-      unless evaluate_script("$$('#attachments a.thumbnail img').first().naturalWidth != 0")
+    find("#attachments a.attachment img").synchronize do
+      unless evaluate_script("$$('#attachments a.attachment img').first().naturalWidth != 0")
         raise Capybara::ExpectationNotMet.new("Thumbnail could not be loaded")
       end
     end

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -89,10 +89,10 @@ class PageSidebarTest < JavascriptIntegrationTest
   end
 
   def test_attach_file
-    assert_no_selector '#attachments a.thumbnail'
+    assert_no_selector '#attachments a.attachment'
     attach_file_to_page
     check_attachment_thumbnail
     remove_file_from_page
-    assert_no_selector '#attachments a.thumbnail'
+    assert_no_selector '#attachments a.attachment'
   end
 end

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -92,6 +92,7 @@ class PageSidebarTest < JavascriptIntegrationTest
     assert_no_selector '#attachments a.attachment'
     attach_file_to_page
     check_attachment_thumbnail
+    assert_selector '#attachments a.attachment'
     remove_file_from_page
     assert_no_selector '#attachments a.attachment'
   end


### PR DESCRIPTION
We recently discussed how browser based image scaling improved a lot throughout the last years.
Let's make use of this and fit the attachment previews into the sidebar.
Show one, two or three attachments per row in the sidebar - based on screen size:
![bildschirmfoto von 2015-07-20 10 55 06](https://cloud.githubusercontent.com/assets/102902/8772573/8f98a194-2ecd-11e5-99e5-25818b40a11b.png)
![bildschirmfoto von 2015-07-20 10 54 18](https://cloud.githubusercontent.com/assets/102902/8772574/8f9c6d06-2ecd-11e5-9f92-98802c259739.png)
![bildschirmfoto von 2015-07-20 10 53 50](https://cloud.githubusercontent.com/assets/102902/8772575/8fa368e0-2ecd-11e5-88cb-29c16de4804a.png)
