### PR TITLE
fix: crash when trying to render notice without post

### DIFF
--- a/app/models/notice/notice.rb
+++ b/app/models/notice/notice.rb
@@ -34,6 +34,11 @@ class Notice < ActiveRecord::Base
     where(dismissed: false).update_all dismissed: true, dismissed_at: Time.now
   end
 
+  def initialize(*args)
+    super
+    self.data ||= Hash.new
+  end
+
   ##
   ## INSTANCE METHODS
   ##
@@ -89,12 +94,10 @@ class Notice < ActiveRecord::Base
   end
 
   def display_attr(attr)
-    if data.is_a? Hash
-      if data[attr].is_a? Array
-        I18n.t(*data[attr])
-      else
-        I18n.t(data[attr], count: 1)
-      end
+    if data[attr].is_a? Array
+      I18n.t(*data[attr])
+    else
+      I18n.t(data[attr], count: 1)
     end
   rescue
     Rails.logger.error "Invalid attribute #{attr} in Notice ##{id}."

--- a/app/models/notice/post_starred_notice.rb
+++ b/app/models/notice/post_starred_notice.rb
@@ -5,7 +5,7 @@ class PostStarredNotice < Notice
 
   def display_title
     I18n.t :activity_twinkled,
-      user: data[:from], post: noticable.body.truncate(39)
+      user: data[:from], post: display_body.truncate(39)
   end
 
   def display_body_as_quote?
@@ -13,7 +13,7 @@ class PostStarredNotice < Notice
   end
 
   def display_body
-    noticable.body
+    noticable.try.body || ""
   end
 
   def noticable_path

--- a/test/unit/notice/post_starred_notice_test.rb
+++ b/test/unit/notice/post_starred_notice_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class PostStarredNoticeTest < ActiveSupport::TestCase
+
+  def test_render_without_post
+    notice = PostStarredNotice.new
+    assert notice.display_title.present?
+    assert_equal "", notice.display_body
+  end
+
+
+end

--- a/test/unit/notice/private_message_notice_test.rb
+++ b/test/unit/notice/private_message_notice_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require 'test_helper'
 
 class PrivateMessageNoticeTest < ActiveSupport::TestCase
   fixtures :users


### PR DESCRIPTION
I guess the post was removed by now. Need to be robust against this
anyway even though we should eventually remove all notices whose
noticables have been destroyed.