### PR TITLE
Move to new comment after page reloaded

### DIFF
--- a/app/controllers/pages/posts_controller.rb
+++ b/app/controllers/pages/posts_controller.rb
@@ -32,7 +32,7 @@ class Pages::PostsController < ApplicationController
   def show
     respond_to do |format|
       format.js   { render 'common/posts/show' }
-      format.html { redirect_to page_url(@page) + "#posts-#{@post.id}" }
+      format.html { redirect_to page_url(@page) + "#post-#{@post.id}" }
     end
   end
 
@@ -40,7 +40,7 @@ class Pages::PostsController < ApplicationController
     if @post = @page.add_post(current_user, post_params)
       respond_to do |format|
         format.js   { redirect_to action: :index }
-        format.html { redirect_to page_url(@page) + "#posts-#{@post.id}" }
+        format.html { redirect_to page_url(@page) + "#post-#{@post.id}" }
       end
     end
   end


### PR DESCRIPTION
Here is simplest fix for feature requested by `@knister` > "After writing and sending a comment, page reloads but jumps back to the first page of comments, NOT to the page, where the comment had been posted. it’s not a big problem, but just kind of annoying." (https://we.riseup.net/riseup+crabgrass/test-new-version-of-crabgrass#recently-fixed)

It was reproduced only with Javascript disabled, just because anchor name is `#post-id` rather than `#posts-id`.