### PR TITLE
Homepage queries optimization

### DIFF
--- a/app/controllers/me/notices_controller.rb
+++ b/app/controllers/me/notices_controller.rb
@@ -5,8 +5,12 @@ class Me::NoticesController < Me::BaseController
   def index
     @notices = Notice.for_user(current_user).
       dismissed(params[:view] == 'old').
+      includes(:noticable).
       paginate(pagination_params.merge(order: "created_at desc"))
-    @pages = current_user.pages.not_deleted.order('pages.updated_at desc').limit(30)
+
+    @pages = current_user.pages.not_deleted.
+      includes(:owner, :updated_by).
+      order('pages.updated_at desc').limit(30)
   end
 
   def show


### PR DESCRIPTION
Hi!

Here is small fix for N + 1 problem because not preloaded data at `me/index` action.

Only pages and notices was loaded in controller but deep in partials we had:
```ruby
url = self.send(notice.noticable_path, notice.noticable) # `noticable` association
```
```ruby
= link_to_entity(page.owner, avatar: :xsmall) # `owner` association
```
```ruby
= link_to_entity(page.updated_by, avatar: :xsmall)  # `updated_by` association aka user
```
Logs comparison https://gist.github.com/aliaksandrb/7fa318f10cce05446d50

The performance measures might be not so precise because was done locally and might be affected by other software was running at my laptop.

Maybe in future it would be great to setup kind of independent container for such testing, using `Vagrant` or `Docker` for example.. 

What do you think, is it worth to care?