### PR TITLE
Feature: Grouping for groups directory

### DIFF
--- a/app/stylesheets/ui/_directory.scss
+++ b/app/stylesheets/ui/_directory.scss
@@ -39,4 +39,8 @@
       margin-right: 5px;
     }
   }
+
+  .groups-wrapper {
+    padding-left: 2em;
+  }
 }

--- a/app/views/groups/directory/_groups.html.haml
+++ b/app/views/groups/directory/_groups.html.haml
@@ -1,11 +1,15 @@
 .directory
-  - @groups.count.times do |i|
-    - group = @groups[i]
-    - if group
-      .entry
-        = render partial: 'group', locals: {group: group}
-    - if @groups[i+1]
-      .divider
+  - @groups.group_by(&:type).each do |type, groups_list|
+    %h1= type.blank? ? :groups.t : type.downcase.pluralize.to_sym.t
+    .divider
+    .groups-wrapper
+      - groups_list.count.times do |i|
+        - group = groups_list[i]
+        - if group
+          .entry
+            = render partial: 'group', object: group
+        - if groups_list[i+1]
+          .divider
 
 = pagination_links(@groups, params: params.except(:utf8))
 


### PR DESCRIPTION
Here is small feature implementation, required here https://we.riseup.net/riseup+crabgrass/test-new-version-of-crabgrass#ease-of-use-clarity

maquis > "when I click on “see all groups” there is just a long list with no difference made between networks, groups, councils etc. Among other things, being able to distinguishing between the different types of groups would help people to find what they’re looking for."

A few screenshots how it looks like:

![index](https://cloud.githubusercontent.com/assets/526022/8887355/55f1015e-3286-11e5-9abe-280c15b50533.png)
![search](https://cloud.githubusercontent.com/assets/526022/8887356/55f3df8c-3286-11e5-8f5c-9ecdf22428e6.png)

