### PR TITLE
revert wiki decoration changes, move to class

### DIFF
--- a/app/helpers/wikis/sections_helper.rb
+++ b/app/helpers/wikis/sections_helper.rb
@@ -1,65 +1,16 @@
 module Wikis::SectionsHelper
 
   def decorate_wiki_sections(wiki, section=:document)
-    doc = Hpricot(wiki.body_html)
-    doc.search('h4 a.anchor, h3 a.anchor, h2 a.anchor, h1 a.anchor').each do |anchor|
-      subsection = anchor['href'].sub(/^.*#/, '')
-      add_edit_link_to_heading(wiki, anchor, subsection) if wiki.edit_sections?
-      wrap_in_div(wiki, doc, subsection, section == :document)
-    end
-    doc.to_html.html_safe
-  rescue WikiExtension::Sections::SectionNotFoundError
-    wiki.body_html
+    decorator = Wiki::Decorator.new wiki, self
+    decorator.decorate section
+    decorator.to_html.html_safe
   end
 
-  private
-
-  def find_heading_node(doc, section)
-    return nil if section.nil?
-    anchor = doc.at("a[@name=#{section}]")
-    return anchor.parent if anchor.present?
-  end
-
-  #
-  # there are a lot of classes assigned to each edit link:
-  # * "wiki-section-edit" is used to hide links when a section is being edited.
-  # * "shy" is used to show the link only when the mouse is over
-  #
-  def add_edit_link_to_heading(wiki, anchor, section)
-    heading = anchor.parent
-    link = link_to_remote(:edit.t,
+  def edit_wiki_section_link(wiki, section)
+    link_to_remote :edit.t,
       {url: edit_wiki_path(wiki, section: section), method: 'get'},
       title: :wiki_section_edit.t, id: "#{section}_edit_link",
       icon: 'pencil', class: 'edit shy wiki-section-edit'
-    )
-    heading.insert_after(Hpricot(link), anchor)
-    heading.attributes['class'] += " shy_parent"
   end
-
-  def wrap_in_div(wiki, doc, section, is_full_wiki)
-    # this is the heading node we want to wrap with its content
-    heading = find_heading_node(doc, section)
-    return if heading.blank?
-    # everything between replace_node and next_node should be wrapped
-
-    end_before = find_heading_node(doc, wiki.successor_for_section(section).try.name)
-
-    # these nodes should be wrapped
-    wrapped_nodes = []
-
-    to_wrap = [heading]
-    last = heading
-    current = heading.try.next_sibling
-    while current != end_before and current
-      to_wrap << current
-      old = current
-      current = current.next_sibling
-      old.parent.children.delete(old)
-    end
-    wrap = heading.make("<div id='#{dom_id(wiki, section.underscore)}'></div>").first
-    heading.parent.replace_child(heading, wrap)
-    wrap.html(to_wrap)
-  end
-
 end
 

--- a/app/models/wiki/decorator.rb
+++ b/app/models/wiki/decorator.rb
@@ -1,0 +1,68 @@
+class Wiki::Decorator
+
+  delegate :to_html, to: :doc
+  attr_reader :wiki, :doc, :view
+
+  def initialize(wiki, view)
+    @wiki = wiki
+    @doc = Hpricot(wiki.body_html)
+    @view = view
+  end
+
+  def decorate(section)
+    doc.search('h4 a.anchor, h3 a.anchor, h2 a.anchor, h1 a.anchor').each do |anchor|
+      subsection = anchor['href'].sub(/^.*#/, '')
+      add_edit_link_to_heading(wiki, anchor, subsection)
+      wrap_in_div(wiki, doc, subsection, section == :document)
+    end
+    doc
+  end
+
+  protected
+
+  def find_heading_node(doc, section)
+    return nil if section.nil?
+    anchor = doc.at("a[@name=#{section}]")
+    if anchor.nil?
+      raise Wiki::SectionNotFoundError.new(section)
+    end
+    anchor.parent
+  end
+
+  #
+  # there are a lot of classes assigned to each edit link:
+  # * "wiki-section-edit" is used to hide links when a section is being edited.
+  # * "shy" is used to show the link only when the mouse is over
+  #
+  def add_edit_link_to_heading(wiki, anchor, section)
+    heading = anchor.parent
+    link = view.edit_wiki_section_link(wiki, section)
+    heading.insert_after(Hpricot(link), anchor)
+    heading.attributes['class'] += " shy_parent"
+  end
+
+  def wrap_in_div(wiki, doc, section, is_full_wiki)
+    # this is the heading node we want to wrap with its content
+    heading = find_heading_node(doc, section)
+    # everything between replace_node and next_node should be wrapped
+
+    end_before = find_heading_node(doc, wiki.successor_for_section(section).try.name) rescue nil
+
+    # these nodes should be wrapped
+    wrapped_nodes = []
+
+    to_wrap = [heading]
+    last = heading
+    current = heading.try.next_sibling
+    while current != end_before and current
+      to_wrap << current
+      old = current
+      current = current.next_sibling
+      old.parent.children.delete(old)
+    end
+    wrap = heading.make(view.div_for(wiki, section.underscore)).first
+    heading.parent.replace_child(heading, wrap)
+    wrap.html(to_wrap)
+  end
+
+end

--- a/extensions/pages/wiki_page/test/integration/wiki_test.rb
+++ b/extensions/pages/wiki_page/test/integration/wiki_test.rb
@@ -63,6 +63,26 @@ and some content
     assert_selector 'li.toc1'
   end
 
+  def test_section_editing
+    content = update_wiki <<-EOWIKI
+h2. section to keep
+
+kept content
+
+h2. section to edit
+
+with content
+    EOWIKI
+    update_section "section to edit", <<-EOSEC
+h2. edited section
+
+with content
+    EOSEC
+    assert_selector "h2", text: 'edited section'
+    assert_no_selector "h2", text: 'section to edit'
+    assert_selector "h2", text: 'section to keep'
+  end
+
   def assert_wiki_unlocked
     request_urls = page.driver.network_traffic.map(&:url)
     assert request_urls.detect{|u| u.end_with? '/lock'}.present?

--- a/test/helpers/integration/comments.rb
+++ b/test/helpers/integration/comments.rb
@@ -1,5 +1,9 @@
+require_relative 'navigation'
+
 module Integration
   module Comments
+    include Integration::Navigation
+
     def post_comment(text = nil)
       text ||= Faker::Lorem.paragraph
       fill_in :post_body, with: text
@@ -13,15 +17,6 @@ module Integration
         click_on 'Save'
       end
       new_text
-    end
-
-    def hover_and_edit(text)
-      target = page.find('.shy_parent', text: text)
-      target.hover
-      within ".shy_parent:hover" do
-        find("a.shy", text: 'Edit').click
-        yield if block_given?
-      end
     end
   end
 end

--- a/test/helpers/integration/navigation.rb
+++ b/test/helpers/integration/navigation.rb
@@ -17,5 +17,14 @@ module Integration
         yield
       end
     end
+
+    def hover_and_edit(text)
+      target = page.find('.shy_parent', text: text)
+      target.hover
+      within ".shy_parent:hover" do
+        find("a.shy", text: 'Edit').click
+        yield if block_given?
+      end
+    end
   end
 end

--- a/test/helpers/integration/wiki.rb
+++ b/test/helpers/integration/wiki.rb
@@ -12,6 +12,15 @@ module Integration
       # work around not being on edit to begin with
       select_page_tab 'Edit'
       content ||= Faker::Lorem.paragraphs(4).join("\n")
+      submit_wiki_with content
+    end
+
+    def update_section(section, content)
+      hover_and_edit section
+      submit_wiki_with content
+    end
+
+    def submit_wiki_with(content)
       within('form.edit_wiki') do
         fill_in 'wiki[body]', with: content
         click_on 'Save'


### PR DESCRIPTION
I tried to fix a bunch of issues that came up during wiki decoration lately.
Turns out i completely broke section editing in the end.

So to prevent this for the future we now have an integration test.

I also moved the bulk of the wiki decoration from the helper to a class of
its own - Wiki::Decorator. This way we can unit test the different issues
that come up instead of relying on integration tests.