### PR TITLE
Cache wiki partial

### DIFF
--- a/app/views/groups/home/_sidebox.html.haml
+++ b/app/views/groups/home/_sidebox.html.haml
@@ -1,18 +1,19 @@
-- if @group.committee?
+- cache [@group, current_language] do
+  - if @group.committee?
+    .margin-bottom
+      = :this_is_committee.t(parent_group: link_to_group(@group.parent)).html_safe
+
+  - if @group.profiles.public.summary.present?
+    .profile-text
+      = @group.profiles.public.summary_html
+
+  - if @group.profiles.public.place.present?
+    .margin-bottom
+      %div
+        %b= h @group.profiles.public.place
+
   .margin-bottom
-    = :this_is_committee.t(parent_group: link_to_group(@group.parent)).html_safe
-
-- if @group.profiles.public.summary.present?
-  .profile-text
-    = @group.profiles.public.summary_html
-
-- if @group.profiles.public.place.present?
-  .margin-bottom
-    %div
-      %b= h @group.profiles.public.place
-
-.margin-bottom
-  = :group_membership_count.t(count: @group.users.count)
+    = :group_membership_count.t(count: @group.users.count)
 
 %div
   = join_group_link

--- a/app/views/wikis/wikis/_show.html.haml
+++ b/app/views/wikis/wikis/_show.html.haml
@@ -4,11 +4,12 @@
 - if (notice = wiki_notice()).present?
   -# give it an id so we can hide it with javascript
   #inline-page-notice= notice
-.wiki{data: {diff: wiki.former && wiki_version_path(wiki, wiki.former.version)}}
-  -# the indentation for wikis must be preserved exactly, or
-  -# <pre> blocks get indented by haml.
-  = preserve do
-    - if may_edit_wiki?(wiki)
-      = decorate_wiki_sections(wiki)
-    - else
-      = wiki.body_html
+- cache [wiki, may_edit_wiki?(wiki) && current_language] do
+  .wiki{data: {diff: wiki.former && wiki_version_path(wiki, wiki.former.version)}}
+    -# the indentation for wikis must be preserved exactly, or
+    -# <pre> blocks get indented by haml.
+    = preserve do
+      - if may_edit_wiki?(wiki)
+        = decorate_wiki_sections(wiki)
+      - else
+        = wiki.body_html


### PR DESCRIPTION
The wiki/wiki/_show template is by far the one that takes most of the total
time spend rendering views.

This comes as no surprise as we not only insert the wiki.body_html but parse it
and extend it with the edit links and so on.

So instead of doing this all the time we now cache it based on the wiki (updated_at),
and the users locale if they are allowed to edit the wiki. The latter is necessary
for translating the wiki edit links and their titles.