### PR TITLE
only update the asset symlinks when needed

### DIFF
--- a/extensions/pages/asset_page/app/models/asset_page.rb
+++ b/extensions/pages/asset_page/app/models/asset_page.rb
@@ -14,7 +14,7 @@ class AssetPage < Page
 
   after_save :update_access
   def update_access
-    asset.update_access if asset
+    asset.update_access if asset && public_changed?
   end
 
   def asset


### PR DESCRIPTION
That's only when the page became public or nonpublic