### PR TITLE
Use thinking sphinxs delayed delta indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,11 @@ gem 'prototype_legacy_helper', '0.0.0',
 # so, we bind to the latest in the version 2 series for now
 gem 'thinking-sphinx', '~> 2.1.0', :require => 'thinking_sphinx'
 
+#
+# Use delayed job to postpone the delta processing
+# latest version available. Stick to major release
+gem 'ts-delayed-delta', '~> 2.0'
+
 # Enhanced Tagging lib. Used to tag pages
 # Could not get the migration rake task for acts-as-taggable-on 3.x to work
 # before rails 3.2.
@@ -152,6 +157,9 @@ gem 'mime-types', :require => 'mime/types'
 # process heavy tasks asynchronously
 # 4.0 is most recent right now. fix major version.
 gem 'delayed_job_active_record', '~> 4.0'
+
+# delayed job runner as a deamon
+gem 'daemons'
 
 # ?
 gem 'rails3_before_render'

--- a/Gemfile
+++ b/Gemfile
@@ -150,8 +150,8 @@ gem 'crabgrass_media', '~> 0.0.2', :require => 'media'
 gem 'mime-types', :require => 'mime/types'
 
 # process heavy tasks asynchronously
-# TODO: why is this locked to 3.0 ?
-gem 'delayed_job', '~> 3.0.5'
+# 4.0 is most recent right now. fix major version.
+gem 'delayed_job_active_record', '~> 4.0'
 
 # ?
 gem 'rails3_before_render'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,9 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
+    ts-delayed-delta (2.0.2)
+      delayed_job
+      thinking-sphinx (>= 1.5.0)
     tzinfo (0.3.44)
     uglifier (2.5.3)
       execjs (>= 0.3.0)
@@ -248,6 +251,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 3.2.2)
   crabgrass_media (~> 0.0.2)
+  daemons
   debugger
   delayed_job_active_record (~> 4.0)
   factory_girl_rails
@@ -281,6 +285,7 @@ DEPENDENCIES
   therubyracer
   thin
   thinking-sphinx (~> 2.1.0)
+  ts-delayed-delta (~> 2.0)
   uglifier (>= 1.0.3)
   uglify_html!
   undress!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,8 +100,11 @@ GEM
       debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.5)
-    delayed_job (3.0.5)
-      activesupport (~> 3.0)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.2.1)
@@ -246,7 +249,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.2)
   crabgrass_media (~> 0.0.2)
   debugger
-  delayed_job (~> 3.0.5)
+  delayed_job_active_record (~> 4.0)
   factory_girl_rails
   faker (~> 1.0.0)
   greencloth!

--- a/app/models/page_terms.rb
+++ b/app/models/page_terms.rb
@@ -82,7 +82,7 @@ class PageTerms < ActiveRecord::Base
       has :flow
 
       # index options
-      set_property delta: true
+      set_property delta: ThinkingSphinx::Deltas::DelayedDelta
       set_property field_weights: {tags: 12, title: 8, body: 4, comments: 2}
     rescue
       ::Rails.logger.warn "failed to index page #{self.id} for sphinx search"

--- a/config/misc/schedule.rb
+++ b/config/misc/schedule.rb
@@ -34,7 +34,11 @@ every 1.hour, :at => '0:30' do
   curl 'tracking_update_hourlies'
 end
 
-every 1.hour, :at => '0:40' do
+# reindex currently takes R = 80sec.
+# delta index takes d = 5ms longer for each document in the delta.
+# Minimum total time is for delta growing up to
+#    sqr( 2*R / d) ~ 180 documents
+every 6.hour, :at => '0:40' do
   curl 'sphinx_reindex'
 end
 

--- a/db/migrate/20150810092223_add_queue_to_delayed_jobs.rb
+++ b/db/migrate/20150810092223_add_queue_to_delayed_jobs.rb
@@ -1,0 +1,9 @@
+class AddQueueToDelayedJobs < ActiveRecord::Migration
+  def self.up
+    add_column :delayed_jobs, :queue, :string
+  end
+
+  def self.down
+    remove_column :delayed_jobs, :queue
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150810090844) do
+ActiveRecord::Schema.define(:version => 20150810092223) do
 
   create_table "activities", :force => true do |t|
     t.integer  "subject_id"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(:version => 20150810090844) do
     t.string   "locked_by"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "queue"
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], :name => "delayed_jobs_priority"

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -6,11 +6,11 @@
 Install for development
 ====================================================
 
-Install basic ruby environment
+Install basic ruby environment (at least ruby 1.9.3, ideally ruby 2.1)
 
 On a debian-based system:
 
-    sudo apt-get install ruby1.9.1 ruby1.9.1-dev rake mysql-server
+    sudo apt-get install ruby ruby-dev rake mysql-server
     mysql-client libmysqld-dev git make libssl-dev g++ sphinxsearch
 
 Depending on what you are running, you might need to install `git-core`
@@ -101,7 +101,7 @@ Install for production
 install prerequisites
 ----------------------
 
-Download and install ruby 1.9 , rubygems, rails, and mysql the same way as
+Download and install ruby, rubygems, rails, and mysql the same way as
 in the 'install for development' instructions.
 
 Then:

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -98,6 +98,19 @@ Run tests:
 Install for production
 ====================================================
 
+setup the environment
+---------------------
+
+Many of the following commands require RAILS_ENV to be set. You can do so
+for the current session with
+    export RAILS_ENV=production
+
+You may also want to add this to your shell environment by default.
+
+Alternatively you can prefix the commands involving rails or rake like this
+
+    RAILS_ENV=production bundle exec rails c
+
 install prerequisites
 ----------------------
 
@@ -107,7 +120,6 @@ in the 'install for development' instructions.
 Then:
 
     apt-get install sphinxsearch
-    export RAILS_ENV=production
     bundle install
 
 `sphinxsearch` is not technically required, but crabgrass runs 100 times faster
@@ -139,7 +151,6 @@ set the permissions:
 
 initialize the database:
 
-    export RAILS_ENV=production
     rake cg:convert_to_unicode
     rake db:schema:load
 
@@ -169,6 +180,18 @@ easiest way to do this is to set up a crontab. The gem `whatever` will install
 one for you from the schedule.rb config file.
 
     whenever --update-crontab -f config/misc/schedule.rb
+
+start delayed job daemon
+--------------------
+
+We index updated documents in sphinx using delayed job.
+(ts-delayed-delta to be exact).
+Run delayed job as a daemon so it can start the jobs:
+
+    script/delayed_job start
+
+You may want to symlink script/delayed_job from your start script directory
+such as /etc/init.d
 
 Configuration options
 ====================================================


### PR DESCRIPTION
Thinking Sphinx will now create a delayed job for every indexing task.

This way the indexing will happen in a separate worker task and rails
can respond faster.

In order for this to work the delayed job tasks need to be run. That's
what the script/delayed_job script is for. You can start it as a daemon:
```
  RAILS_ENV=production script/delayed_job start
```

Running the delta indexing asynchronous also reduces the need for
reindexing. The delta index may grow and delta indexing may be slow -
but it won't delay the response anymore.

Therefore this commit also sets the reindex frequency to 6 hours. Here's
the math behind this:

R denotes the time the reindex takes and d denotes the additional time
required by a doc in the delta index for a single index run. Then the
average index time per document when growing the delta index up to n
documents is:

 t(n) = R/n + d(n+1)/2

This function has a minimum at n_opt = sqr(2R/d). For our production install
R = 80s and d = 2.5 ms. So n_opt ~ 180 documents. We should have a few
less in 6 hours. So there is room to grow.

I hope to speed up reindexing with a new version of sphinx and higher
mem_limit. Then recalculating this might be interesting. But for now
sphinx should not be a performance bottle neck anymore.

