### PR TITLE
bugfix: make reindex cron action work

### DIFF
--- a/app/controllers/cron_controller.rb
+++ b/app/controllers/cron_controller.rb
@@ -29,7 +29,9 @@ class CronController < ActionController::Base
     when 'codes_expire'
       Code.cleanup_expired
     when 'sphinx_reindex'
-      system('rake', '--rakefile', Rails.root+'/Rakefile', 'ts:index', 'RAILS_ENV=production')
+      require 'rake'
+      require 'thinking_sphinx/tasks'
+      Rake::Task["ts:rebuild"].invoke
     else
       raise 'no such cron action'
     end


### PR DESCRIPTION
The Rails.root path would have required a .to_s. But the whole
idea of running the rake task via system makes no sense in the
context of the CronController.

As the comment above says:

So there is no point in using this mechanism to run system calls.

I'm wondering though if it's a clever idea to require rake and
the thinking sphinx tasks in a controller.