### PR TITLE
bugfix: make reindex cron action work

### DIFF
--- a/app/controllers/cron_controller.rb
+++ b/app/controllers/cron_controller.rb
@@ -28,8 +28,6 @@ class CronController < ActionController::Base
       clean_fragment_cache
     when 'codes_expire'
       Code.cleanup_expired
-    when 'sphinx_reindex'
-      system('rake', '--rakefile', Rails.root+'/Rakefile', 'ts:index', 'RAILS_ENV=production')
     else
       raise 'no such cron action'
     end

--- a/config/misc/schedule.rb
+++ b/config/misc/schedule.rb
@@ -39,7 +39,7 @@ end
 # Minimum total time is for delta growing up to
 #    sqr( 2*R / d) ~ 180 documents
 every 6.hour, :at => '0:40' do
-  curl 'sphinx_reindex'
+  rake 'ts:index'
 end
 
 every 1.day do


### PR DESCRIPTION
The Rails.root path would have required a .to_s. But the whole
idea of running the rake task via system makes no sense in the
context of the CronController.

Instead we now use whenevers rake type.

rake ts:index takes 80 seconds total, 3 of those are for startup.
No point in blocking a passenger process for 80 seconds to avoid
the 3 second startup.

this superseeds pr #307 on github