### PR TITLE
Release/0.6.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,18 @@
+Changes in Crabgrass 0.6.2
+--------------------------
+
+Another bugfix release. This one has seen some serious speed improvements in
+particular for updates that update a page.
+The main user visible changes are the return of wiki diffs and stars for
+comments. Also we sort group and user lists alphabetically in a number of
+places now.
+We also prepared the upgrade to rails 4 as much as possible. So we removed all
+mods and turned the other rails 2.3 style plugins into engines that will be
+compatible with rails4. We also moved all the activity tracking that was using
+observers before into controllers. We now use helper classes to keep controllers
+thin but trigger the action tracking from the controllers themselves.
+
+
 Changes in Crabgrass 0.6.1
 --------------------------
 

--- a/app/controllers/pages/participations_controller.rb
+++ b/app/controllers/pages/participations_controller.rb
@@ -82,7 +82,7 @@ class Pages::ParticipationsController < Pages::SidebarsController
   # watching group participations.
   def fetch_data
     return unless params[:access] && params[:id]
-    if params[:group]
+    if params[:group] && params[:group]!= 'false'
       @part = @page.group_participations.find(params[:id])
     else
       @part = @page.user_participations.find(params[:id])

--- a/extensions/pages/task_list_page/app/controllers/tasks_controller.rb
+++ b/extensions/pages/task_list_page/app/controllers/tasks_controller.rb
@@ -71,7 +71,9 @@ class TasksController < Pages::BaseController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description, :user_ids => [])
+    params.require(:task).
+      reverse_merge(user_ids: []).
+      permit(:name, :description, :user_ids => [])
   end
 
   def sort_params

--- a/extensions/pages/task_list_page/test/functional/tasks_controller_test.rb
+++ b/extensions/pages/task_list_page/test/functional/tasks_controller_test.rb
@@ -3,14 +3,15 @@ require 'test_helper'
 class TasksControllerTest < ActionController::TestCase
   fixtures :pages, :users, :task_lists, :tasks
 
-  def test_sort
-    login_as :blue
-
+  def setup
     @user = users(:blue)
     @page = pages(:tasklist1)
     @page.add(@user, access: :admin)
     @page.save!
+    login_as @user
+  end
 
+  def test_sort
     assert_equal 1, Task.find(1).position
     assert_equal 2, Task.find(2).position
     assert_equal 3, Task.find(3).position
@@ -24,11 +25,19 @@ class TasksControllerTest < ActionController::TestCase
   end
 
   def test_create_task
-    login_as :blue
-    pages(:tasklist1).add(users(:blue), access: :admin)
-    pages(:tasklist1).save!
-    assert_difference 'pages(:tasklist1).data.tasks.count' do
-      xhr :post, :create, page_id: pages(:tasklist1).id, task: {name: "new task", user_ids: ["5"], description: "new task description"}
+    assert_difference '@page.data.tasks.count' do
+      xhr :post, :create, page_id: @page.id,
+        task: {name: "new task", user_ids: ["5"], description: "new task description"}
+    end
+  end
+
+  def test_update_task
+    list = @page.data
+    task = list.tasks.create name: 'blue... do something!',
+      user_ids: [@user.id]
+    assert_difference '@user.tasks.count', -1 do
+      xhr :put, :update, page_id: @page, id: task.id,
+        task: {name: "updated task", description: "new task description"}
     end
   end
 end

--- a/extensions/pages/task_list_page/test/integration/task_list_test.rb
+++ b/extensions/pages/task_list_page/test/integration/task_list_test.rb
@@ -29,7 +29,14 @@ class TaskListTest < JavascriptIntegrationTest
     assign_task_to users(:red)
     assert_task_assigned_to users(:red)
     unassign_task_from user
-    assert_task_not_assigned_to users(:blue)
+    assert_no_task_assigned_to users(:blue)
+  end
+
+  def test_unassigning_task_from_last_user
+    add_task
+    unassign_task_from user
+    assert_tasks_pending
+    assert_no_task_assigned_to(user)
   end
 
   def add_task(options = {})
@@ -44,7 +51,9 @@ class TaskListTest < JavascriptIntegrationTest
 
   def unassign_task_from(user)
     edit_task
-    uncheck user.login
+    within '#sort_list_pending' do
+      uncheck user.login
+    end
     click_on 'Save'
   end
 
@@ -94,7 +103,7 @@ class TaskListTest < JavascriptIntegrationTest
     end
   end
 
-  def assert_task_not_assigned_to(*users)
+  def assert_no_task_assigned_to(*users)
     users.each do |user|
       assert_no_selector '.people',
         text: user.display_name

--- a/test/helpers/integration/javascript/page_actions.rb
+++ b/test/helpers/integration/javascript/page_actions.rb
@@ -66,7 +66,11 @@ module PageActions
     click_on 'Page Details'
     find('a', text: 'Permissions').click
     select permission
-    assert_selector "#permissions_tab .tiny_#{PERMISSION_ICONS[permission]}_16"
+    if PERMISSION_ICONS.keys.include? permission
+      assert_selector "#permissions_tab .tiny_#{PERMISSION_ICONS[permission]}_16"
+    else
+      wait_for_ajax
+    end
     close_popup
     wait_for_ajax # reload sidebar
   end

--- a/test/helpers/integration/javascript/page_actions.rb
+++ b/test/helpers/integration/javascript/page_actions.rb
@@ -74,12 +74,14 @@ module PageActions
   def delete_page(page = @page)
     click_on 'Delete Page'
     click_button 'Delete'
+    wait_for_ajax
     # ensure after_commit callbacks are triggered so sphinx indexes the page.
     page.page_terms.committed!
   end
 
   def undelete_page(page = @page)
     click_on 'Undelete'
+    wait_for_ajax
     # ensure after_commit callbacks are triggered so sphinx indexes the page.
     page.page_terms.committed!
   end

--- a/test/integration/image_test.rb
+++ b/test/integration/image_test.rb
@@ -2,6 +2,11 @@ require 'integration_test'
 
 class ImageTest < IntegrationTest
 
+  def setup
+    FileUtils.mkdir_p(ASSET_PRIVATE_STORAGE)
+    FileUtils.mkdir_p(ASSET_PUBLIC_STORAGE)
+  end
+
   def test_get_asset
     asset = FactoryGirl.create :image_asset
     visit asset.url

--- a/test/integration/page_sidebar_test.rb
+++ b/test/integration/page_sidebar_test.rb
@@ -57,6 +57,15 @@ class PageSidebarTest < JavascriptIntegrationTest
     assert_page_starred
   end
 
+  def test_remove_user_from_page
+    @page.add(users(:red), access: :admin)
+    @page.save!
+    visit current_url # reload
+    assert_page_users users(:blue), users(:red)
+    change_access_to 'No Access'
+    assert_page_users users(:blue)
+  end
+
   def test_trash
     path = current_path
     delete_page

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -14,11 +14,6 @@ class ProfileTest < ActiveSupport::TestCase
     FileUtils.mkdir_p(ASSET_PUBLIC_STORAGE)
   end
 
-  def teardown
-    FileUtils.rm_rf(ASSET_PRIVATE_STORAGE)
-    FileUtils.rm_rf(ASSET_PUBLIC_STORAGE)
-  end
-
   def test_adding_profile
     u = users(:blue)
     p = u.profiles.create stranger: true, first_name: 'Blue'

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -1,9 +1,7 @@
 require_relative 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
-
-  def setup
-  end
+  fixtures :users
 
   def test_creation
     assert list = TaskList.create
@@ -45,4 +43,13 @@ class TaskTest < ActiveSupport::TestCase
     assert_nil t.completed_at
   end
 
+  def test_unassigning_from_last_user
+    list = TaskList.create
+    task = list.tasks.create
+    task.user_ids = [users(:blue).id]
+    task.save
+    task.user_ids = []
+    task.save
+    assert_equal [], task.user_ids
+  end
 end


### PR DESCRIPTION
Another bugfix release. This one has seen some serious speed improvements in
particular for updates that update a page.
The main user visible changes are the return of wiki diffs and stars for
comments. Also we sort group and user lists alphabetically in a number of
places now.
We prepared the upgrade to rails 4 as much as possible. So we removed mods
and turned the other rails 2.3 style plugins into rails4 compatible engines.
We moved tracking of user activity from observers into controllers. We now
use helper classes to keep controllers thin but trigger them
from the controllers themselves.

List of changes:

Release preparation
 * fix tests failing locally

Pull request #308 from azul/bugfix/ts-cron
 * bugfix: make reindex cron action work

Pull request #305 from azul/performance/delayed-index
 * use thinking sphinxs delayed delta indexing
 * recommend ruby 2.1 over 1.9 in INSTALL docs
 * upgrade: delayed job to latest and run migrate task

Pull request #304 from azul/performance/page-terms-index
 * add index on delta column to page_terms

Pull request #303 from azul/profile/page-updates
 * benchmark: page updates - indexing and user_participation
 * little update to install statement, as libsqlite3-dev seems to be necessary for sqlite3 gem used for castle_gates tests.
 * Fix to not show 'with this message' in page notice unless there is actually a mesage refs #9914

Pull request #301 from azul/bugfix/wiki-cache-diffs
 * don't cache the wiki diff flags

Pull request #300 from azul/bugfix/notice_list
 * prevent /me crashes on invalid notices

Pull request #299 from azul/bugfix/wiki-links
 * fix umlaut issues in page titles and anchors
 * turn greencloth test into real test

Pull request #298 from azul/bugfix/update-access-only-if-needed
 * only update the asset symlinks when needed

Pull request #297 from azul/performance/cache_wiki
 * performance: cache group sidebox
 * performance: cache wiki template

Pull request #296 from azul/refactor/separate-media
 * fix and test odt conversion
 * refactor: separate crabgrass_media repository

Pull request #294 from aliaksandrb/groups_directory_grouping
 * Feature: Grouping for groups directory

Pull request #295 from azul/bugfix/section-edit
 * revert wiki decoration changes, move to class

Pull request #291 from aliaksandrb/page_reload_after_new_comment
 * Move to new comment after page reloaded

Pull request #288 from aliaksandrb/9735_group_and_people_directory_is_not_alphabetized
 * Show people directory entities alphabetized

Pull request #293 from aliaksandrb/mysql_queries_optimizations
 * Homepage queries optimization

Pull request #290 from azul/bugfix/missing-sections
 * hotfix to work around changes in wiki section naming

Pull request #292 from azul/revert/too-loose-regexp
 * Revert wiki toc - handle multiline headings better

Pull request #287 from azul/bugfix/uninitialized-section-not-found
 * cleanup error handling - in particular Wiki section not found

Pull request #286 from azul/bugfix/double_render_group_join
 * prevent double render on create RequestToJoinYou

Pull request #284 from azul/bugfix/star-notice-with-post-removed
 * fix: crash when trying to render notice without post

Pull request #285 from azul/ui/attachment-tweaks
 * border and a bit of box shadow for attachments

Pull request #283 from azul/bugfix/request_to_remove_user
 * bugfix: fix request to remove user from group

Pull request #282 from azul/bugfix/multiline-headings-in-toc
 * wiki toc - handle multiline headings better
 * pop up toc heading error on wiki save

Pull request #281 from azul/ui/responsive-attachments
 * test: debug pending ajax request on travis
 * responsive attachment images in sidebar

Pull request #280 from azul/performance/pdf-processing
 * performance: create small jpgs from large ones

Pull request #279 from aliaksandrb/error_with_sending_message
 * Private message before discussion fix

Pull request #278 from azul/performance/pdf-processing
 * try converting first page of pdf only

Pull request #277 from azul/bugfix/flash_message_now
 * fix 500 caused by flash_message_now

Pull request #276 from azul/bugfix/asset-page-500
 * Make type changes test work on CI
 * bugfix: 500 on trying to convert xcf
 * move rjs into view from controller update block

Pull request #275 from azul/bugfix/approve-request-error
 * bugfix: fix 500 when approving RequestToRemoveUser

Pull request #274 from azul/upgrade/prepare-for-rails4
 * replace scopes with class methods in models
 * clean up model access in accounts_controller some
 * drop unused sweepers
 * start replacing scopes with defs or use lambdas
 * replace render :update with rjs partials
 * remove RemoteJob for Assets
 * make sure test names are unique
 * routes: remove duplicates and always specify verb(s)
 * remove last remains of attr_accessible
 * format validations with \A \z instead of ^ and $

Pull request #273 from azul/bugfix/messages_page_error
 * display proper error if there is no discussion yet

Pull request #272 from azul/bugfix/create-comments-without-js
 * Fix creating comments without javascript

Pull request #271 from azul/bugfix/wiki-toc
 * bugfix: duplicate use of section names broke wiki

Pull request #270 from aliaksandrb/anchor_links_for_comments
 * Anchor links for comments

Pull request #269 from aliaksandrb/hide_all_notifications_link
 * Feature: Dismiss all notifications button

Pull request #268 from azul/test/remove-wait-for-ajax
 * remove wait for ajax
 * fix: visit public group without login

Pull request #266 from aliaksandrb/private_message_deletion
 * Delete private message action does not hide it
 * Feature: Add Send Message link to a user profile

Pull request #263 from azul/feature/sorted-menus
 * Sort entities in top menu alphabetically

Pull request #262 from azul/bugfix/full-wiki-diff
 * only show diff if old version was present

Pull request #259 from azul/bugfix/version-without-asset
 * return 404 on show missing asset with version

Pull request #260 from azul/bugfix/cancel-wiki-edit
 * fix: canceling wiki edits renders wiki

Pull request #261 from azul/i18n/update_es
 * improve spanish translation [skip-ci]

Pull request #238 from azul/bugfix/prevent-500-on-old-link-encoding
 * prevent 500 for links that still use url encodes iso chars

Pull request #258 from azul/feature/wiki-diff
 * enable wiki diffs for group wikis
 * integration tests for displaying wiki diffs
 * keep edit links and the like out of diffs
 * render wiki diffs on page load
 * insert former html into div for cleaner diff
 * show diff when displaying wiki versions
 * regression test - create committee with dup name

Pull request #256 from aliaksandrb/9686_translation_missed_for_network_group_invite_notification
 * Exception: Translation missed for network group invite notification

Pull request #255 from aliaksandrb/9676_notification_for_group_invite_is_missed
 * Notifications for group invite are missed

Pull request #254 from aliaksandrb/9675_contact_notification_request_missed
 * Missed notification for contact request

Pull request #257 from aliaksandrb/3292_ability_to_remove_account_setting_image
 * Feature: Ability to remove account settings avatar

Pull request #253 from azul/bugfix/make-page-public
 * bugfix: turn pages public and private without error

Pull request #251 from aliaksandrb/9656_doubled_images
 * Fix for incremental images upload to a gallery with D'n'D

Pull request #252 from azul/bugfix/email-invites
 * fix email invites, includes test
 * make sure not to confuse Common::Tracking with ::Tracking

Pull request #245 from aliaksandrb/8493_message_notification_and_its_deletions
 * Dismiss private message notification for deleted message

Pull request #250 from azul/cleanup/remove-direct-upload
 * cleanup: remove direct data upload from assets

Pull request #249 from azul/bugfix/assets-without-filename
 * make sure assets have a filename if upload aborts

Pull request #248 from azul/bugfix/notification
 * fix: notifications were broken by checkbox options
 * add task to reset star counters
 * fix stars for comments upgrade task and js
 * add regression test for private message failure

Pull request #247 from azul/hotfix/fix_private_posts
 * make comments and messages more robust

Pull request #244 from azul/feature/stars-for-comments
 * notify people when their posts were starred
 * rake: migrate ratings to stars for Posts
 * adopt tests for starring to actual workflow
 * css: use n-th of type for background stars
 * css: use n-th-child-of-type instead of .odd and .even
 * use redirects to PagePostsController#show to rerender comments
 * display stars in the background of posts
 * fix star_post_action to use ujs toggle
 * ujs links with toggling icons and spinner in between
 * send proper status_code on exceptions
 * First steps towards staring posts

Pull request #246 from aliaksandrb/thin_dependency
 * Update the Thin gem dependency for Ruby > 2
 * Merge branch '9524_my_task_icon_missed' of https://github.com/aliaksandrb/crabgrass-core
 * Fix for tasks icon missed in the main menu
 * consider_all_requests_local should be true in dev mode.

Pull request #242 from azul/refactor/castle-gates-reload
 * fix castle gates reloading in development

Pull request #241 from azul/upgrade/minitest
 * no need to check may_show_group? twice
 * update test environment - minitest 4.7 and mocha 1.1
 * upgrade rails to include latest security patches

Pull request #240 from azul/refactor/page-history-tracking
 * namespace all the tracking things
 * track wiki updates in controller - no more observers!
 * track_actions for all participation tracking
 * fix participation tracking, actually use it
 * Track granting user access with track_action
 * PageHistory::GrantUserAccess with access level as attribute
 * track granting group access from controller
 * prepare Pages::SharesController for replacing participation observers
 * complete refactor of PageShare
 * cleanup: no need to hand over the page in PageShare
 * no more options to share.with
 * move all page sharing stuff into PageShare
 * split up may_share_with_user!
 * split up may_share! into may_share_with_{user,group}!
 * replace User#share_page_with!
 * introduce PageShare to share with multiple recipients
 * separate unit tests - share page with one or many
 * test page sharing with page history creation
 * refactor Page::ShareController
 * refactor Pages::SharesController actions a bit
 * Use GrantGroupAccess to replace GrantGroup...Access
 * use proper Page:: namespace for page unit tests
 * refactor page_history helper
 * more robust gallery integration test
 * track page updates in controller not observer
 * track_actions in Pages::PostsController
 * properly load class methods in particular track_actions
 * use track_actions and track_action
 * Turn Activity.track into generic Tracking::Action.track

Pull request #234 from azul/refactor/callbacks-and-observers
 * validate in_reply_to in post
 * refactor: move private message sending into relationship
 * only include activity tracking when needed.
 * replace relationship observer with init_discussion
 * track request to destroy group in controller
 * track event for group destruction via request
 * track FriendActivity in controller not observer
 * remove user observer, prepare user destroyed notices
 * handle request notices from controller not observer
 * replace Reqest.after_destroy with dependent: delete association
 * track activities for create_membership when using requests
 * track request approval with request specific event - failing test
 * only send attributes that can be set in Activity.track
 * remove page_observer - use dependent: delete for PageNotices
 * no more message wall for now.
 * use Activity.track and dependent: delete for private posts
 * use destroy action for removing posts
 * replace membership observer with track_activity
 * keep list of activity classes as strings not constants
 * helper method track_activity in controllers
 * tests: reuse of committee names accross groups
 * use form_for for new groups and committees
 * Group created activity in controller, failing test
 * cleanup: Groups::GroupsController
 * use param[:group] for all group types
 * refactor: Add users to group they created in controller
 * Notification class to notify in different ways
 * test: fix tests that failed 1 hour before midnight
 * rewrite: destroy group using the powers of rails

Pull request #239 from azul/test/group-destruction
 * remove hacks for requests where group is gone
 * Test group destruction and approve requests without js

Pull request #237 from elijh/feature/tasks
 * tasks: added 'my tasks' view, and improved tasks ui.
 * forbid bad avatar size names, by routing.

Pull request #232 from azul/test/exception-controller
 * test exceptions controller

Pull request #231 from azul/bugfix/oo-doc-icon
 * icon OpenOffice docs is oo_document not oo_text

Pull request #229 from azul/bugfix/error-handling
 * bring back ErrorNotFound, drop per site i18n

Pull request #230 from azul/feature/print-url
 * bring back the context/page/print url - at least for wikis

Pull request #225 from azul/bugfix/gallery-image-show-html
 * only handle remote links on left button click
 * bugfix: render gallery image show as html as well

Pull request #226 from riseuplabs/master
 * accept param to raise_not_found even if it's unused
 * fix controller_symbol for nil param and error log in PublicExceptions
 * do not rely on may_edit_group being included
 * only propose to create a page for groups i may edit

Pull request #224 from riseuplabs/develop

Pull request #219 from azul/refactor/not-found
 * make task lists integration test more robust
 * functional test actual page destruction
 * fix creating page from link (such as new wiki pages)
 * use head :not_found instead of ErrorNotFound for ajax
 * fix functional tests for 404s raising exceptions
 * use custom subclass of AD::PublicExceptions
 * raise AR::RecordNotFound in raise_not_found
 * first take on using an exception app for 404s

Pull request #222 from riseuplabs/develop

Pull request #223 from azul/test/try-container-build
 * libreoffice can't be installed in container builds for now
 * try to cache bundler
 * travis: use container based infrastructure

Pull request #221 from azul/bugfix/wiki-toc
 * bugfix: display toc for wikis

Pull request #220 from riseuplabs/develop
 * i18n: update translations from transifex
 * i18n: also download riseup specific translations from transifex

Pull request #218 from azul/bugfix/asset-error
 * bring back ods thumbdef.
 * return 404 if asset can not be found

Pull request #217 from azul/cleanup/mod-routes
 * cleanup: mod_routes - no more need for them without mods

Pull request #216 from riseuplabs/develop

Pull request #215 from azul/bugfix/editing-private-posts
 * fix editing private posts

Pull request #214 from azul/bugfix/avatar-paths
 * remove new avatar action, avoid polymorphic path
 * fix polymorphic avatar path

Pull request #213 from riseuplabs/develop

Pull request #212 from azul/bugfix/last-page-of-comments
 * display the last page of the comments by default

Pull request #211 from azul/debug/contex-url
 * debug output to fix NoMethodError in GroupSettings
 * i18n update from transifex
 * do not try to load missing audio preview partial
 * do not try to load missing audio preview partial

Pull request #210 from riseuplabs/develop

Pull request #208 from elijh/bugfix/anonposts
 * a few fixes for page comments when the user is not authenticated.

Pull request #209 from azul/bugfix/production_issues
 * meaningful guess for thumbnail url with undefined thumbnail type
 * ranked vote: don't bomb out if viewing a ranked vote while not logged in. closes #9409
 * pin .ruby-version to match what is on production server.
 * fix group destruction bug (closes #9410)

Pull request #207 from riseuplabs/develop
 * tests: we require login for accessing the search now
 * riseup theme: added note about red and black accounts
 * for now, require authentication to browse the directory of users or groups
 * Merge branch 'develop' of ssh://github.com/riseuplabs/crabgrass-core into develop

Pull request #206 from azul/rewrite/crabgrass-plugins
 * plugins: bring back deplrecation warnings
 * plugins: drop crabgrass_acts_as_tree - only used in one place
 * plugins: load without rails 2.3 mechanism
 * plugins: after_reload turned into a lib

Pull request #204 from azul/cleanup/mods
 * cleanup: remove all traces of MODS

Pull request #205 from azul/bugfix/production-500
 * 404 when releasing locks for removed section

Pull request #203 from azul/rewrite/page-engines
 * turn all pages into engines
 * Crabgrass::Page::Engine module with register_page_type
 * use initializer method for page registration
 * pages: use engine instead of plugin for discussion page
 * update spanish translation
 * transifex fixes: add transifex link to footer, fix pull url in rake task, include bundled en.yml in git.