### PR TITLE
Generator for new pagetypes

### DIFF
--- a/lib/generators/pagetype/USAGE
+++ b/lib/generators/pagetype/USAGE
@@ -1,0 +1,24 @@
+Description:
+    Create a new pagetype to use in crabgrass.
+    Running this generator will enable the creation of pages of a new type
+    inside crabgrass:
+    * Click on "Create New Page" in the 'me' menu.
+    * Pick the new pagetype - probably last in the selection
+    * fill in the fields for the page and create the page
+    This will create a page of the new pagetype. Of course the specific
+    functionality still needs to be added.
+
+Example:
+    rails generate pagetype bird
+
+    This will create:
+        extensions/pages/bird_page
+    and preseed it with an engine, model and controller for the pagetype.
+
+    Inside the engine definition it will register the pagetype with
+    crabgrass and activate it in
+      config/crabgrass/crabgrass.development.yml
+    so it can be played with.
+
+    A dummy pagetype description will be added to
+      config/locales/en/pages.yml

--- a/lib/generators/pagetype/pagetype_generator.rb
+++ b/lib/generators/pagetype/pagetype_generator.rb
@@ -1,0 +1,41 @@
+class PagetypeGenerator < Rails::Generators::NamedBase
+  desc "This generator creates a new pagetype and registers it in crabgrass"
+  source_root File.expand_path('../templates', __FILE__)
+
+  def create_crabgrass_engine
+    template 'crabgrass_engine.rb.erb',
+      "extensions/pages/#{name}_page/lib/crabgrass_#{name}_page.rb"
+  end
+
+  def create_page_class
+    template 'page.rb.erb',
+      "extensions/pages/#{name}_page/app/models/#{name}_page.rb"
+  end
+
+  def create_controller_class
+    template 'page_controller.rb.erb',
+      "extensions/pages/#{name}_page/app/controllers/#{name}_page_controller.rb"
+  end
+
+  def create_view
+    create_file "extensions/pages/#{name}_page/app/views/#{name}_page/show.html.haml"
+  end
+
+  def add_translation
+    append_to_file 'config/locales/en/pages.yml', <<-EOT
+  #{name}_page_description: "Please adjust this translation in config/locales/en/pages.yml!"
+  #{name}_page_display: "#{class_name}"
+    EOT
+  end
+
+  def activate_page_type
+    gsub_file 'config/crabgrass/crabgrass.development.yml',
+      "available_page_types:\n",
+      "available_page_types:\n  - #{class_name}Page\n"
+    # remove duplicates
+    gsub_file 'config/crabgrass/crabgrass.development.yml',
+      "\n  - #{class_name}Page\n  - #{class_name}Page\n",
+      "\n  - #{class_name}Page\n"
+  end
+
+end

--- a/lib/generators/pagetype/templates/crabgrass_engine.rb.erb
+++ b/lib/generators/pagetype/templates/crabgrass_engine.rb.erb
@@ -1,0 +1,15 @@
+require 'crabgrass/page/engine'
+
+module Crabgrass<%= class_name %>Page
+  class Engine < ::Rails::Engine
+    include Crabgrass::Page::Engine
+
+    register_page_type :<%= class_name %>Page,
+      controller: ['<%= name %>_page'],
+      model: '<%= name %>',
+      icon: 'page_<%= name %>',
+      class_group: ['planning', '<%= name %>'],
+      order: 5
+  end
+end
+

--- a/lib/generators/pagetype/templates/page.rb.erb
+++ b/lib/generators/pagetype/templates/page.rb.erb
@@ -1,0 +1,11 @@
+# <%= class_name %>Page
+
+class <%= class_name %>Page < Page
+
+  # define search terms specific to <%= class_name %>Page
+  # for the full text search index
+  def body_terms
+    ""
+  end
+
+end

--- a/lib/generators/pagetype/templates/page_controller.rb.erb
+++ b/lib/generators/pagetype/templates/page_controller.rb.erb
@@ -1,0 +1,5 @@
+class <%= class_name %>PageController < Pages::BaseController
+
+  def show
+  end
+end


### PR DESCRIPTION
Description:
    Create a new pagetype to use in crabgrass.
    Running this generator will enable the creation of pages of a new type
    inside crabgrass:
    * Click on "Create New Page" in the 'me' menu.
    * Pick the new pagetype - probably last in the selection
    * fill in the fields for the page and create the page
    This will create a page of the new pagetype. Of course the specific
    functionality still needs to be added.

Example:
    rails generate pagetype bird

    This will create:
        extensions/pages/bird_page
    and preseed it with an engine, model and controller for the pagetype.

    Inside the engine definition it will register the pagetype with
    crabgrass and activate it in
      config/crabgrass/crabgrass.development.yml
    so it can be played with.

    A dummy pagetype description will be added to
      config/locales/en/pages.yml