### PR TITLE
cron: drop cache cleanup tasks

### DIFF
--- a/app/controllers/cron_controller.rb
+++ b/app/controllers/cron_controller.rb
@@ -22,10 +22,6 @@ class CronController < ActionController::Base
       Tracking::Page.process
     when 'tracking_update_dailies'
       Tracking::Daily.update
-    when 'cache_session_clean'
-      clean_session_cache
-    when 'cache_fragment_clean'
-      clean_fragment_cache
     when 'codes_expire'
       Code.cleanup_expired
     else
@@ -44,22 +40,6 @@ class CronController < ActionController::Base
     unless request.remote_addr == '127.0.0.1'
       render text: 'not allowed'
     end
-  end
-
-  #
-  # remove all files that have had their status changed more than three days ago.
-  # (on a system with user accounts, tmpreaper should be used instead.)
-  #
-  def clean_fragment_cache
-    system("find", Rails.root+'/tmp/cache', '-ctime', '+3', '-exec', 'rm', '{}', ';')
-  end
-
-  #
-  # remove all files that have had their status changed more than three days ago.
-  # (on a system with user accounts, tmpreaper should be used instead.)
-  #
-  def clean_session_cache
-    system("find", Rails.root+'/tmp/sessions', '-ctime', '+3', '-exec', 'rm', '{}', ';')
   end
 
 end

--- a/config/misc/schedule.rb
+++ b/config/misc/schedule.rb
@@ -45,11 +45,6 @@ every 6.hour, :at => '0:40' do
 end
 
 every 1.day do
-  curl 'cache_session_clean'
   curl 'codes_expire'
   curl 'tracking_update_dailies'
-end
-
-every 3.days do
-  curl 'cache_fragment_clean'
 end


### PR DESCRIPTION
There's no point in triggering a request with curl to then call
system from the controller.

Also... we want to keep fragment caches for more than just 3 days.
Currently we have about a month of caches and they occupy a total of
< 800MB. Many of them are probably page list entries and i bet they still are
used even if they have not been updated in a while.