### PR TITLE
Feature/wikiversion - fix test for #310

### DIFF
--- a/app/models/wiki_extension/sections.rb
+++ b/app/models/wiki_extension/sections.rb
@@ -15,6 +15,7 @@ module WikiExtension
     def save_section!(section, text)
       section = structure.find_section(section) unless section.is_a? GreenTree
       updated_body = section.sub_markup(text)
+      return if self.body == updated_body
       self.body = updated_body
       self.save!
     end

--- a/app/models/wiki_extension/versioning.rb
+++ b/app/models/wiki_extension/versioning.rb
@@ -34,13 +34,18 @@ module WikiExtension
       end
     end
 
-    def create_new_version?
+    def create_new_version? #:nodoc:
+      body_updated = body_changed?
+      recently_edited_by_same_user = !user_id_changed? && (updated_at and (updated_at > 30.minutes.ago))
+
+      latest_version_has_blank_body = self.versions.last && self.versions.last.body.blank?
+
       # always create a new version if we have no versions at all
-      return true if versions.empty?
       # don't create a new version if
       #   * a new version would be on top of an old blank version (we don't want to store blank versions)
+      #   * the same user is making several edits in sequence
       #   * the body hasn't changed
-      body_changed? and !versions.last.body.blank?
+      return (versions.empty? or (body_updated and !recently_edited_by_same_user and !latest_version_has_blank_body))
     end
 
     def current

--- a/app/models/wiki_extension/versioning.rb
+++ b/app/models/wiki_extension/versioning.rb
@@ -35,17 +35,15 @@ module WikiExtension
     end
 
     def create_new_version? #:nodoc:
-      body_updated = body_changed?
-      recently_edited_by_same_user = !user_id_changed? && (updated_at and (updated_at > 30.minutes.ago))
-
-      latest_version_has_blank_body = self.versions.last && self.versions.last.body.blank?
-
       # always create a new version if we have no versions at all
-      # don't create a new version if
-      #   * a new version would be on top of an old blank version (we don't want to store blank versions)
-      #   * the same user is making several edits in sequence
-      #   * the body hasn't changed
-      return (versions.empty? or (body_updated and !recently_edited_by_same_user and !latest_version_has_blank_body))
+      return true if versions.empty?
+      # overwrite blank versions (we don't want to store blank versions)
+      return false if current.body.blank?
+      body_changed? && ( user_id_changed? || long_time_no_updates? )
+    end
+
+    def long_time_no_updates?
+      updated_at && (updated_at < 30.minutes.ago)
     end
 
     def current

--- a/app/permissions/wikis_permission.rb
+++ b/app/permissions/wikis_permission.rb
@@ -18,6 +18,8 @@ module WikisPermission
     current_user.may?(:admin, (wiki.page || wiki.group))
   end
 
+  # you can revert, if the version you want to revert to
+  # is not already the last version.
   def may_revert_wiki_version?(version = @version)
     version.next && may_edit_wiki?(version.wiki)
   end

--- a/extensions/pages/wiki_page/test/functional/wikis/versions_controller_test.rb
+++ b/extensions/pages/wiki_page/test/functional/wikis/versions_controller_test.rb
@@ -13,21 +13,24 @@ class Wikis::VersionsControllerTest < ActionController::TestCase
     wiki = pages(:wiki).data
 
     # create versions
-    (1..5).zip([:orange, :yellow, :blue, :red, :purple]).each do |i, user|
-      login_as user
-      wiki.update_section!(:document, users(user), i, "text %d for the wiki" % i)
+    %w[yellow orange blue yellow red purple].each do |user|
+      wiki.update_section! :document, users(user), nil,
+        "text from %s for the wiki" % user
     end
-
-    wiki.update_section!(:document, users(:purple), 6, "text 6 for the wiki")
 
     login_as :orange
     wiki.versions.reload
 
+    assert_equal 6, wiki.versions.count
+    assert_equal 6, wiki.versions.last.version
+
     # find versions
-    get :show, wiki_id: wiki.id, id: 6
+    get :show, wiki_id: wiki.id, id: 5
     assert_response :success
-    assert_equal 6, assigns(:version).version
-    assert_equal 'text 6 for the wiki', assigns(:wiki).body
+    assert_equal 5, assigns(:version).version
+    assert_equal 'text from purple for the wiki', assigns(:wiki).body
+    assert_equal 'text from red for the wiki', assigns(:version).body
+    assert_equal 4, assigns(:former).version
   end
 
   def test_show_invalid_version

--- a/test/helpers/wiki_test_helper.rb
+++ b/test/helpers/wiki_test_helper.rb
@@ -1,0 +1,28 @@
+module WikiTestHelper
+
+  def assert_latest_body wiki, body
+    assert_equal body, wiki.body, "should have the latest body"
+    assert_equal body, wiki.versions.last.body, "should have the latest body for its most recent version"
+  end
+
+  def assert_latest_body_html wiki, body_html
+    assert_equal body_html, wiki.body_html, "should have the latest body_html"
+    assert_equal body_html, wiki.versions.last.body_html, "should have the latest body_html for its most recent version"
+  end
+
+  def assert_latest_raw_structure wiki, raw_structure
+    assert_equal raw_structure, wiki.raw_structure, "should have the latest raw_structure"
+    assert_equal raw_structure, wiki.versions.last.raw_structure, "should have the latest raw_structure for its most recent version"
+  end
+
+  def wiki_raw_structure_for_n_byte_body(n)
+    {
+      name: nil,
+      children: [],
+      start_index: 0,
+      end_index: n - 1,
+      heading_level: 0
+    }
+  end
+
+end

--- a/test/unit/wiki/locking_test.rb
+++ b/test/unit/wiki/locking_test.rb
@@ -1,274 +1,282 @@
-module Wiki::LockingTest
+require_relative '../test_helper'
 
-  def self.included(base)
-    base.instance_eval do
+#
+# there are some unusually written tests in the form "msg".tap{|msg| assert true, msg}
+# it is done this way to make it easier to port these tests from rspec.
+#
 
-      context "A new unsaved wiki" do
-        setup do
-          @wiki = Wiki.new
-        end
+class Wiki::LockingTest < ActiveSupport::TestCase
+  fixtures :users, :wikis
 
-        context "after locking" do
-          setup do
-            assert_nothing_raised {@wiki.lock!(:document, @user) }
-          end
+  def setup
+    @user = users(:blue)
+    @different_user = users(:red)
+  end
 
-          should_change("the number of saved wikis", by: 1) { Wiki.count }
-          should_change("the number of wiki locks", by: 1) { WikiLock.count }
-
-          should "get saved" do
-            assert !@wiki.new_record?
-          end
-
-          should "get a valid wiki lock object created" do
-            assert_equal @user.id, WikiLock.find_by_wiki_id(@wiki.id).locks[:document][:by]
-          end
+  def test_wiki_after_locking
+    @wiki = Wiki.new
+    assert_difference "Wiki.count" do
+      assert_difference "WikiLock.count" do
+        assert_nothing_raised do
+          @wiki.lock!(:document, @user)
         end
       end
+    end
+    assert !@wiki.new_record?, "wiki should be saved"
+    lock = WikiLock.find_by_wiki_id(@wiki.id)
+    refute_nil lock, 'lock should exist'
+    lock_user = lock.locks[:document][:by]
+    assert_equal @user.id, lock_user, 'lock user should be set'
+  end
 
-      context "A Wiki with many sections" do
+  def test_lock_missing_section
+    # currently, locking sections that don't exist just fails silently:
+    #assert_raises(Wiki::LockedError, "should raise LockedError when locking a non-existant section") do
+    #  @wiki.lock! 'bad-nonexistant-section-header', @user
+    #end
+    #assert_raises(Wiki::LockedError, "should raise LockedError when unlocking a non-existant section") do
+    #  @wiki.unlock! 'bad-nonexistant-section-header', @user
+    #end
+  end
 
-        setup do
-          @wiki = wikis(:multi_section)
-
-          @user = users(:blue)
-          @different_user = users(:red)
-        end
-
-        should "raise WikiLockError when locking a non-existant section" do
-          assert_raises(WikiLockError) {@wiki.lock! 'bad-nonexistant-section-header', @user}
-        end
-
-        should "raise WikiLockError when unlocking a non-existant section" do
-          assert_raises(WikiLockError) {@wiki.unlock! 'bad-nonexistant-section-header', @user}
-        end
-
-        context "when a user locks 'section-two'" do
-          setup { @wiki.lock! 'section-two', @user }
-
-          should "not raise WikiLockError when locking 'section-two' section again" do
-            assert_nothing_raised {@wiki.lock! 'section-two', @user}
-          end
-
-          context "and a different user renames 'section-two' bypassing locks" do
-            setup do
-              body = @wiki.body.sub('section two', 'section 2')
-              @wiki.update_attributes!({user: @different_user, body: body, body_html: nil})
-            end
-
-            should "have no section locked for either user" do
-              assert @wiki.sections_locked_for(@user).empty?
-              assert @wiki.sections_locked_for(@different_user).empty?
-            end
-
-            should "have all sections open for either user" do
-              assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user)
-              assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@different_user)
-            end
-          end
-
-          context "and a different user renames 'section-two' without saving" do
-            setup do
-              @wiki.body = @wiki.body.sub('section two', 'section 2')
-            end
-
-            should "have no section locked for either user" do
-              assert @wiki.sections_locked_for(@user).empty?
-              assert @wiki.sections_locked_for(@different_user).empty?
-            end
-
-            should "have all sections open for either user" do
-              assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user)
-              assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@different_user)
-            end
-          end
-
-
-          context "and a different user locks 'section-one'" do
-            setup { @wiki.lock! 'section-one', @different_user }
-
-            should "appear to that user that 'section-two' is open" do
-              assert @wiki.sections_open_for(@user).include?('section-two')
-            end
-
-            should "appear to the different user that 'section-one' is open" do
-              assert @wiki.sections_open_for(@different_user).include?('section-one')
-            end
-          end
-
-          should "return 'section-two' from section_edited_by" do
-            assert_equal 'section-two', @wiki.section_edited_by(@user)
-          end
-
-          should "be nil from section_edited_by for a section_edited_by user" do
-            assert_nil @wiki.section_edited_by(@different_user)
-          end
-
-          context "and that user unlocks 'section-two'" do
-            setup { @wiki.unlock! 'section-two', @user }
-
-            should "appear the same to that user and to a different user" do
-              assert_same_elements @wiki.sections_open_for(@user), @wiki.sections_open_for(@different_user)
-              assert_same_elements @wiki.sections_locked_for(@user), @wiki.sections_locked_for(@different_user)
-            end
-
-            should "appear to a different user that all sections can be edited and none are locked" do
-              assert_same_elements @wiki.sections_open_for(@different_user), @wiki.all_sections
-              assert @wiki.sections_locked_for(@different_user).empty?
-            end
-          end
-
-          context "for that user" do
-            test_open_sections = [:document, 'top-oversection',
-                                  'section-two', 'subsection-for-section-two', 'section-one', 'second-oversection']
-
-            test_open_sections.each { |section_heading|
-              should "have the #{section_heading.inspect} section open" do
-                assert @wiki.sections_open_for(@user).include?(section_heading)
-                assert !@wiki.sections_locked_for(@user).include?(section_heading)
-              end
-
-
-              should "raise no errors when unlocking #{section_heading.inspect} section" do
-                assert_nothing_raised {@wiki.unlock! section_heading, @user}
-              end
-            }
-
-          end
-
-          context "for a different user" do
-            setup {@user = @different_user}
-
-            test_closed_sections = [:document, 'top-oversection', 'section-two', 'subsection-for-section-two']
-
-            test_closed_sections.each { |section_heading|
-              should "have the #{section_heading.inspect} section closed" do
-                assert !@wiki.sections_open_for(@user).include?(section_heading)
-                assert @wiki.sections_locked_for(@user).include?(section_heading)
-              end
-
-              should "raise WikiLockError when locking #{section_heading.inspect} section" do
-                assert_raises(WikiLockError) {@wiki.lock! section_heading, @user}
-              end
-
-              should "raise WikiLockError when unlocking #{section_heading.inspect} section" do
-                assert_raises(WikiLockError) {@wiki.unlock! section_heading, @user}
-              end
-            }
-
-            should "have the neighborhing sections open" do
-              assert @wiki.sections_open_for(@user).include?('section-one')
-              assert !@wiki.sections_locked_for(@user).include?('section-one')
-
-              assert @wiki.sections_open_for(@user).include?('second-oversection')
-              assert !@wiki.sections_locked_for(@user).include?('second-oversection')
-            end
-
-            should "raise no errors when unlocking neighboring section" do
-              assert_nothing_raised {@wiki.unlock! 'section-one', @user }
-              assert_nothing_raised {@wiki.unlock! 'second-oversection', @user }
-            end
-
-            should "not raise WikiLockError when trying to break the lock for 'section-two'" do
-              assert_nothing_raised {@wiki.unlock! 'section-two', @user, break: true}
-            end
-          end
-        end
-
-        context "when a user locks the whole document" do
-          setup {@wiki.lock! :document, @user}
-
-          should "appear that this user is a locker_of document" do
-            assert_equal @user, @wiki.locker_of(:document)
-          end
-
-          should "appear that this user is a locker_of a subsection" do
-            assert_equal @user, @wiki.locker_of('section-one')
-          end
-
-          should "appear to the same user that document is open for editing" do
-            assert @wiki.document_open_for?(@user)
-          end
-
-          should "appear to the same user that a document subsection is open for editing" do
-            assert @wiki.section_open_for?('section-one', @user)
-          end
-
-          should "appear to a different user that document is locked for editing" do
-            assert @wiki.document_locked_for?(@different_user)
-          end
-
-          should "appear to a different user that a document subsection is locked for editing" do
-            assert @wiki.section_locked_for?('section-one', @different_user)
-          end
-
-          context "and then that user unlocks the whole document" do
-            setup {@wiki.unlock! :document, @user}
-
-            should "appear that no user is a locker_of document" do
-              assert_nil @wiki.locker_of(:document)
-            end
-
-            should "appear that no user is a locker_of a subsection" do
-              assert_nil @wiki.locker_of('section-one')
-            end
-
-            should "appear the same to that user and to a different user" do
-              assert_same_elements @wiki.sections_open_for(@user), @wiki.sections_open_for(@different_user)
-              assert_same_elements @wiki.sections_locked_for(@user), @wiki.sections_locked_for(@different_user)
-            end
-
-            should "appear to a different user that all sections can be edited and none are locked" do
-              assert_same_elements @wiki.sections_open_for(@different_user), @wiki.all_sections
-              assert @wiki.sections_locked_for(@different_user).empty?
-            end
-          end
-
-          should "appear to that user that all sections can be edited and none are locked" do
-            assert_same_elements @wiki.sections_open_for(@user), @wiki.all_sections
-            assert @wiki.sections_locked_for(@user).empty?
-          end
-
-          should "appear to a different user that no sections can be edited and all are locked" do
-            assert @wiki.sections_open_for(@different_user).empty?
-            assert_same_elements @wiki.sections_locked_for(@different_user), @wiki.all_sections
-          end
-
-          should "raise an exception (and keep the same state) when a different user tries to lock the document" do
-            assert_raises(WikiLockError) {@wiki.lock! :document, @different_user}
-
-            assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user)
-            assert @wiki.sections_open_for(@different_user).empty?
-            assert_same_elements @wiki.all_sections, @wiki.sections_locked_for(@different_user)
-          end
-
-          should "raise an exception (and keep the same state) when a different user tries to lock a section" do
-            assert_raises(WikiLockError) {@wiki.lock! 'section-one', @different_user}
-
-            assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user)
-            assert @wiki.sections_open_for(@different_user).empty?
-            assert_same_elements @wiki.all_sections, @wiki.sections_locked_for(@different_user)
-          end
-
-          should "raise a WikiLockError if that user tries to lock another section" do
-            assert_raises(WikiLockError) do
-              @wiki.lock! 'section-one', @user
-            end
-          end
-        end
-      end
-
-      # def test_lock_race_condition
-      #   w = wikis(:multi_section)
-      #
-      #   w.lock(Time.now, users(:orange), 'section-one')
-      #   assert_raises(WikiLockError) do
-      #     w2 = Wiki.find(w.id)
-      #     w2.lock(Time.now, users(:blue), 'section-one')
-      #   end
-      #   assert_equal ['section-one'], w.reload.locked_sections
-      #   assert_equal users(:orange).id, w.locked_by_id('section-one')
-      # end
+  def test_double_lock
+    @wiki = wikis(:multi_section)
+    assert_nothing_raised do
+      @wiki.lock! 'section-two', @user
+    end
+    assert_nothing_raised("should not raise Wiki::LockedError when locking 'section-two' section again") do
+      @wiki.lock! 'section-two', @user
     end
   end
+
+  def test_section_rename_while_locked
+    @wiki = wikis(:multi_section)
+    @wiki.lock! 'section-two', @user
+
+    # now a different user goes and modifies the section titles, bypassing locks
+    body = @wiki.body.sub('section two', 'section 2')
+    @wiki.update_attributes!({user: @different_user, body: body, body_html: nil})
+
+    "should be no locks".tap do |msg|
+      assert @wiki.sections_locked_for(@user).empty?, msg
+      assert @wiki.sections_locked_for(@different_user).empty?, msg
+    end
+
+    "should have not section locked for either user".tap do |msg|
+      assert @wiki.sections_locked_for(@user).empty?, msg
+      assert @wiki.sections_locked_for(@different_user).empty?, msg
+    end
+
+    "should have all sections open for either user".tap do |msg|
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user), msg
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@different_user), msg
+    end
+  end
+
+  def test_section_rename_in_memory
+    @wiki = wikis(:multi_section)
+    @wiki.lock! 'section-two', @user
+    @wiki.body = @wiki.body.sub('section two', 'section 2')
+
+    "should have no section locked for either user".tap do |msg|
+      assert @wiki.sections_locked_for(@user).empty?, msg
+      assert @wiki.sections_locked_for(@different_user).empty?, msg
+    end
+
+    "should have all sections open for either user".tap do |msg|
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user), msg
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@different_user), msg
+    end
+  end
+
+  def test_locks_appear_open_and_closed
+    @wiki = wikis(:multi_section)
+    @wiki.lock! 'section-two', @user
+
+    assert_equal 'section-two', @wiki.section_edited_by(@user),
+      "section-two is being edited by user"
+
+    assert_nil @wiki.section_edited_by(@different_user),
+      "should be nil from section_edited_by for a section_edited_by user"
+
+    #
+    # from @user's point of view
+    #
+
+    test_open_sections = [
+      :document, 'top-oversection', 'section-two',
+      'subsection-for-section-two', 'section-one', 'second-oversection'
+    ]
+
+    test_open_sections.each do |section_heading|
+      "should have the #{section_heading.inspect} section open".tap do |msg|
+        assert @wiki.sections_open_for(@user).include?(section_heading), msg
+        assert !@wiki.sections_locked_for(@user).include?(section_heading), msg
+      end
+    end
+
+    #
+    # from @different_user's point of view
+    #
+
+    test_closed_sections = [
+      :document, 'top-oversection', 'section-two',
+      'subsection-for-section-two'
+    ]
+
+    test_closed_sections.each do |section_heading|
+      "should have the #{section_heading.inspect} section closed".tap do |msg|
+        assert !@wiki.sections_open_for(@different_user).include?(section_heading), msg
+        assert @wiki.sections_locked_for(@different_user).include?(section_heading), msg
+      end
+
+      assert_raises(Wiki::SectionLockedError, "should raise Wiki::SectionLockedError when locking #{section_heading.inspect} section") do
+        @wiki.lock! section_heading, @different_user
+      end
+
+      # current behavior is to silently ignore
+      # attempts to unlock something you are not allowed to.
+      #assert_raises(Wiki::SectionLockedError, "should raise Wiki::SectionLockedError when unlocking #{section_heading.inspect} section") do
+      #  @wiki.release_my_lock! section_heading, @user
+      #end
+    end
+
+    "should have the neighborhing sections open".tap do |msg|
+      assert @wiki.sections_open_for(@different_user).include?('section-one'), msg
+      assert !@wiki.sections_locked_for(@different_user).include?('section-one'), msg
+      assert @wiki.sections_open_for(@different_user).include?('second-oversection'), msg
+      assert !@wiki.sections_locked_for(@different_user).include?('second-oversection'), msg
+    end
+
+    #
+    # release locks
+    #
+    test_open_sections.each do |section_heading|
+      assert_nothing_raised "should raise no errors when unlocking #{section_heading.inspect} section" do
+        @wiki.release_my_lock! section_heading, @user
+      end
+    end
+  end
+
+  def test_two_section_locks
+    @wiki = wikis(:multi_section)
+    @wiki.lock! 'section-two', @user
+    @wiki.lock! 'section-one', @different_user
+
+    assert @wiki.sections_open_for(@user).include?('section-two'),
+      "should appear to user that 'section-two' is open"
+
+    assert !@wiki.sections_open_for(@user).include?('section-one'),
+      "should not appear to user that 'section-one' is open"
+
+    assert @wiki.sections_open_for(@different_user).include?('section-one'),
+      "should appear to the different user that 'section-one' is open"
+  end
+
+  def test_lock_then_unlock
+    @wiki = wikis(:multi_section)
+    @wiki.lock! 'section-two', @user
+    @wiki.release_my_lock! 'section-two', @user
+
+    "should appear the same to that user and to a different user".tap do |msg|
+      assert_same_elements @wiki.sections_open_for(@user), @wiki.sections_open_for(@different_user), msg
+      assert_same_elements @wiki.sections_locked_for(@user), @wiki.sections_locked_for(@different_user), msg
+    end
+
+    "should appear to a different user that all sections can be edited and none are locked".tap do |msg|
+      assert_same_elements @wiki.sections_open_for(@different_user), @wiki.all_sections, msg
+      assert @wiki.sections_locked_for(@different_user).empty?, msg
+    end
+  end
+
+  def test_lock_document
+    @wiki = wikis(:multi_section)
+    @wiki.lock! :document, @user
+
+    "should appear that this user is a locker_of document".tap do |msg|
+      assert_equal @user, @wiki.locker_of(:document), msg
+    end
+
+    "should appear that this user is a locker_of a subsection".tap do |msg|
+      assert_equal @user, @wiki.locker_of('section-one'), msg
+    end
+
+    "should appear to the same user that document is open for editing".tap do |msg|
+      assert @wiki.section_open_for?(:document, @user), msg
+    end
+
+    "should appear to the same user that a document subsection is open for editing".tap do |msg|
+      assert @wiki.section_open_for?('section-one', @user), msg
+    end
+
+    "should appear to a different user that document is locked for editing".tap do |msg|
+      assert @wiki.section_locked_for?(:document, @different_user), msg
+    end
+
+    "should appear to a different user that a document subsection is locked for editing".tap do |msg|
+      assert @wiki.section_locked_for?('section-one', @different_user), msg
+    end
+
+    "should appear to that user that all sections can be edited and none are locked".tap do |msg|
+      assert_same_elements @wiki.sections_open_for(@user), @wiki.all_sections, msg
+      assert @wiki.sections_locked_for(@user).empty?, msg
+    end
+
+    "should appear to a different user that no sections can be edited and all are locked".tap do |msg|
+      assert @wiki.sections_open_for(@different_user).empty?, msg
+      assert_same_elements @wiki.sections_locked_for(@different_user), @wiki.all_sections, msg
+    end
+
+    "should raise an exception (and keep the same state) when a different user tries to lock the document".tap do |msg|
+      assert_raises(Wiki::SectionLockedError, msg) do
+        @wiki.lock! :document, @different_user
+      end
+
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user), msg
+      assert @wiki.sections_open_for(@different_user).empty?, msg
+      assert_same_elements @wiki.all_sections, @wiki.sections_locked_for(@different_user), msg
+    end
+
+    "should raise an exception (and keep the same state) when a different user tries to lock a section".tap do |msg|
+      assert_raises(Wiki::SectionLockedError, msg) do
+        @wiki.lock! 'section-one', @different_user
+      end
+
+      assert_same_elements @wiki.all_sections, @wiki.sections_open_for(@user), msg
+      assert @wiki.sections_open_for(@different_user).empty?, msg
+      assert_same_elements @wiki.all_sections, @wiki.sections_locked_for(@different_user), msg
+    end
+
+    "should raise a Wiki::OtherSectionLockedError if that user tries to lock another section".tap do |msg|
+      assert_raises(Wiki::OtherSectionLockedError, msg) do
+        @wiki.lock! 'section-one', @user
+      end
+    end
+  end
+
+  def test_lock_then_unlock_whole_document
+    @wiki = wikis(:multi_section)
+    @wiki.lock! :document, @user
+    @wiki.release_my_lock! :document, @user
+
+    "should appear that no user is a locker_of document".tap do |msg|
+      assert_nil @wiki.locker_of(:document), msg
+    end
+
+    "should appear that no user is a locker_of a subsection".tap do |msg|
+      assert_nil @wiki.locker_of('section-one'), msg
+    end
+
+    "should appear the same to that user and to a different user".tap do |msg|
+      assert_same_elements @wiki.sections_open_for(@user), @wiki.sections_open_for(@different_user), msg
+      assert_same_elements @wiki.sections_locked_for(@user), @wiki.sections_locked_for(@different_user), msg
+    end
+
+    "should appear to a different user that all sections can be edited and none are locked".tap do |msg|
+      assert_same_elements @wiki.sections_open_for(@different_user), @wiki.all_sections, msg
+      assert @wiki.sections_locked_for(@different_user).empty?, msg
+    end
+  end
+
 end
+

--- a/test/unit/wiki/locking_test.rb
+++ b/test/unit/wiki/locking_test.rb
@@ -6,7 +6,7 @@ require_relative '../test_helper'
 #
 
 class Wiki::LockingTest < ActiveSupport::TestCase
-  fixtures :users, :wikis
+  fixtures :users, :wikis, :wiki_versions, :wiki_locks
 
   def setup
     @user = users(:blue)

--- a/test/unit/wiki/section_locking_version_test.rb
+++ b/test/unit/wiki/section_locking_version_test.rb
@@ -1,0 +1,52 @@
+require_relative '../test_helper'
+
+#
+# a test for the interaction of versioning and locking and sections
+#
+
+class Wiki::LockingVersionTest < ActiveSupport::TestCase
+  fixtures :users, :wikis, :wiki_versions, :wiki_locks
+
+  def setup
+    @user1 = users(:blue)
+    @user2 = users(:red)
+    @wiki = wikis(:multi_section)
+  end
+
+  def test_normal_section_save
+    @wiki.lock! 'section-one', @user1
+    @wiki.lock! 'section-two', @user2
+    version = @wiki.version
+    @wiki.update_section!('section-one', @user1, version, "h2. section one\n\n111111111")
+    @wiki.update_section!('section-two', @user2, version, "h2. section two\n\n222222222")
+    assert_equal @user2, @wiki.user
+    assert_equal version+2, @wiki.versions(true).size
+    assert_match /h2\. section one\n\n111111111\n\nh2\. section two\n\n222222222/, @wiki.body, 'should save both sections'
+  end
+
+  def test_version_does_not_increment_for_repeat_section_save
+    version = @wiki.version
+    @wiki.lock! 'section-one', @user1
+    @wiki.update_section!('section-one', @user1, version, "h2. section one\n\n111111111")
+    @wiki.lock! 'section-two', @user1
+    @wiki.update_section!('section-two', @user1, version+1, "h2. section two\n\n222222222")
+    assert_equal version+1, @wiki.versions(true).size, 'version should increment by 1'
+  end
+
+  def test_two_users_repeat_save
+    version = @wiki.version
+    @wiki.lock! 'section-two', @user2
+
+    @wiki.lock! 'section-one', @user1
+    @wiki.update_section!('section-one', @user1, version, "h2. section one\n\n111111111")
+
+    @wiki.lock! 'section-one', @user1
+    @wiki.update_section!('section-one', @user1, version, "h2. section one\n\none one one")
+
+    @wiki.update_section!('section-two', @user2, version, "h2. section two\n\n222222222")
+
+    assert_match /h2\. section one\n\none one one\n\nh2\. section two\n\n222222222/, @wiki.body, 'should save all changes'
+  end
+
+end
+

--- a/test/unit/wiki/versioning_test.rb
+++ b/test/unit/wiki/versioning_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 class Wiki::VersioningTest < ActiveSupport::TestCase
-  fixtures :users, :wikis
+  fixtures :users, :wikis, :wiki_versions
   include WikiTestHelper
 
   def setup
@@ -21,6 +21,7 @@ class Wiki::VersioningTest < ActiveSupport::TestCase
     assert_difference '@wiki.versions.size' do
       @wiki.update_attributes!(body: 'hi', user: @user)
     end
+    assert_equal 1, @wiki.version
     assert_latest_body @wiki, 'hi'
     assert_latest_body_html @wiki, '<p>hi</p>'
     assert_latest_raw_structure @wiki, wiki_raw_structure_for_n_byte_body(2)
@@ -34,6 +35,7 @@ class Wiki::VersioningTest < ActiveSupport::TestCase
     assert_difference '@wiki.versions.size' do
       @wiki.update_attributes!(body: 'hi there', user: @user)
     end
+    assert_equal 2, @wiki.version
 
     #
     # save third version
@@ -43,6 +45,7 @@ class Wiki::VersioningTest < ActiveSupport::TestCase
     assert_no_difference '@wiki.versions.size' do
       assert_nothing_raised { @wiki.save! }
     end
+    assert_equal 2, @wiki.version
     assert_latest_body @wiki, 'hey you'
     assert_latest_body_html @wiki, '<p>hey you</p>'
     assert_latest_raw_structure @wiki, wiki_raw_structure_for_n_byte_body(7)
@@ -96,6 +99,7 @@ class Wiki::VersioningTest < ActiveSupport::TestCase
     assert_equal '2222', @wiki.body,  "should revert wiki body"
     assert_equal 2, @wiki.versions(true).size, "should delete all newer versions"
     assert_equal '2222', @wiki.versions.find_by_version(2).body, "should keep version 2"
+    assert_equal 2, @wiki.version
   end
 
   private

--- a/test/unit/wiki/versioning_test.rb
+++ b/test/unit/wiki/versioning_test.rb
@@ -1,162 +1,130 @@
-require File.dirname(__FILE__) + '/../test_helper'
+require_relative '../test_helper'
 
-module Wiki::VersioningTest
-  def self.included(base)
-    base.instance_eval do
-      context "A new Wiki" do
-        setup do
-          @wiki = Wiki.new
-        end
+class Wiki::VersioningTest < ActiveSupport::TestCase
+  fixtures :users, :wikis
+  include WikiTestHelper
 
-        context "before saving" do
-          should "have no versions" do
-            assert @wiki.versions.empty?
-          end
-        end
-
-        # test chat changing body updates versions only when
-        # a new user does it
-        context "saved with a body by a user" do
-          setup do
-            @wiki.update_attributes!(body: 'hi', user: @user)
-          end
-
-          should_change("versions count", from: 0, to: 1) { @wiki.versions.size }
-
-          context "and then saved with the same body by different user" do
-            setup do
-              @wiki.update_attributes!(user: @different_user)
-            end
-
-            should_not_change("versions count") { @wiki.versions.size }
-          end
-
-          context "and saved with a new body by a different user" do
-            setup do
-              @wiki.update_attributes!(body: 'hi there', user: @different_user)
-            end
-
-            should_change("versions count", from: 1, to: 2) { @wiki.versions.size }
-
-            should_have_latest_body 'hi there'
-            should_have_latest_body_html '<p>hi there</p>'
-            should_have_latest_raw_structure(WikiTest.raw_structure_for_n_byte_body(8))
-          end
-
-          context "and saved with a new body by the same user" do
-            setup do
-              @wiki.body = 'hey you'
-              @wiki.user = users(:blue)
-              assert_nothing_raised { @wiki.save! }
-            end
-
-            should_not_change("versions count") { @wiki.versions.size }
-
-            should_have_latest_body 'hey you'
-            should_have_latest_body_html '<p>hey you</p>'
-            should_have_latest_raw_structure(raw_structure_for_n_byte_body(7))
-          end
-        end
-
-        ### wiki should not create new versions on top of a blank version
-        ['', nil].each do |initial_body|
-          context "saved with #{initial_body.inspect} body by a user" do
-            setup do
-              @wiki.update_attributes!(body: initial_body, user: @user)
-            end
-
-            should_change("versions count", from: 0, to: 1) { @wiki.versions.size }
-
-            should_have_latest_body initial_body
-            should_have_latest_body_html ''
-            should_have_latest_raw_structure(WikiTest.raw_structure_for_n_byte_body(0))
-
-            context "and then saved with new body by a different user" do
-              setup do
-                @wiki.update_attributes!(body: 'oi', user: @user)
-              end
-
-              should_not_change("versions count") { @wiki.versions.size }
-              should_have_latest_body 'oi'
-            end
-
-            context "and then saved with new body by the same user" do
-              setup do
-                @wiki.update_attributes!(body: 'oi', user: @user)
-              end
-
-              should_not_change("versions count") { @wiki.versions.size }
-              should_have_latest_body 'oi'
-            end
-          end
-        end
-
-        context "saved with 'oi', '' (blank body) and 'vey' bodies by alternating users" do
-          setup do
-            @wiki.update_attributes!(body: 'oi', user: @user)
-            @wiki.update_attributes!(body: '', user: @different_user)
-            @wiki.update_attributes!(body: 'vey', user: @user)
-          end
-
-          should_change("versions count", from: 0, to: 2) { @wiki.versions.size }
-
-          should "have only 'oi' and 'vey' versions" do
-            assert_equal ['oi', 'vey'], @wiki.versions.collect(&:body)
-          end
-
-          should "have the right user for its versions" do
-            assert_equal [@user, @user], @wiki.versions.collect(&:user)
-          end
-        end
-
-
-
-        context "with four versions" do
-          setup do
-            @wiki = Wiki.create! body: '1111', user: @user
-            @wiki.update_document!(@different_user, 1, '2222')
-            @wiki.update_document!(@user, 2, '3333')
-            @wiki.update_document!(@different_user, 3, '4444')
-          end
-          should_change("versions count", from: 0, to: 4) { @wiki.versions.size }
-
-          should "find version 1 body" do
-            assert_equal '1111', @wiki.versions.find_by_version(1).body
-          end
-
-          should "find version 4 body" do
-            assert_equal '4444', @wiki.versions.find_by_version(4).body
-          end
-
-          context "after a soft revert to an older version" do
-            setup {@wiki.revert_to_version(3, users(:purple)) }
-
-            should "create a new version equal to the older version" do
-              assert_equal '3333', @wiki.versions.find_by_version(5).body
-            end
-
-            should "revert wiki body" do
-              assert_equal '3333', @wiki.body
-            end
-          end
-
-          context "after a hard revert to an older version" do
-            setup {@wiki.revert_to_version!(2, users(:purple))}
-
-            should "revert wiki body" do
-              assert_equal '2222', @wiki.body
-            end
-
-            should "delete all newer versions" do
-              assert_equal 2, @wiki.versions(true).size
-            end
-
-            should "keep the version it was reverted to" do
-              assert_equal '2222', @wiki.versions.find_by_version(2).body
-            end
-          end
-        end
-      end
-    end
+  def setup
+    @wiki = Wiki.new
+    @user = users(:blue)
+    @different_user = users(:red)
   end
+
+  def test_new_wikis_have_no_versions
+    assert @wiki.versions.empty?
+  end
+
+  def test_save_versions
+    #
+    # save first version
+    #
+    assert_difference '@wiki.versions.size' do
+      @wiki.update_attributes!(body: 'hi', user: @user)
+    end
+    assert_latest_body @wiki, 'hi'
+    assert_latest_body_html @wiki, '<p>hi</p>'
+    assert_latest_raw_structure @wiki, wiki_raw_structure_for_n_byte_body(2)
+    assert_no_difference '@wiki.versions.size', 'saving the same body should never produce a new version' do
+      @wiki.update_attributes!(body: 'hi', user: @different_user)
+    end
+
+    #
+    # save second version
+    #
+    assert_difference '@wiki.versions.size' do
+      @wiki.update_attributes!(body: 'hi there', user: @user)
+    end
+
+    #
+    # save third version
+    #
+    @wiki.body = 'hey you'
+    @wiki.user = @user
+    assert_no_difference '@wiki.versions.size' do
+      assert_nothing_raised { @wiki.save! }
+    end
+    assert_latest_body @wiki, 'hey you'
+    assert_latest_body_html @wiki, '<p>hey you</p>'
+    assert_latest_raw_structure @wiki, wiki_raw_structure_for_n_byte_body(7)
+  end
+
+  def test_initial_empty_body
+    assert_no_new_versions_on_empty_body('')
+  end
+
+  def test_initial_nil_body
+    assert_no_new_versions_on_empty_body(nil)
+  end
+
+  #
+  # save with 'oi', '' (blank body) and 'vey' bodies by alternating users
+  #
+  def test_save_empty_body
+    assert_difference '@wiki.versions.size', 2 do
+      @wiki.update_attributes!(body: 'oi', user: @user)
+      @wiki.update_attributes!(body: '', user: @different_user)
+      @wiki.update_attributes!(body: 'vey', user: @user)
+    end
+
+    assert_equal ['oi', 'vey'], @wiki.versions.collect(&:body),
+      "should have only 'oi' and 'vey' versions"
+
+    assert_equal [@user, @user], @wiki.versions.collect(&:user),
+       "should have the right user for its versions"
+  end
+
+  def test_soft_revert
+    @wiki = Wiki.create! body: '1111', user: @user
+    @wiki.update_attributes!(body: '2222', user: @different_user)
+    @wiki.update_attributes!(body: '3333', user: @user)
+    @wiki.update_attributes!(body: '4444', user: @different_user)
+
+    @wiki.revert_to_version(@wiki.find_version(3), users(:purple))
+    assert_equal '3333', @wiki.versions.find_by_version(5).body,
+      "should create a new version equal to the older version"
+    assert_equal '3333', @wiki.body,
+      "should revert wiki body"
+  end
+
+  def test_hard_revert
+    @wiki = Wiki.create! body: '1111', user: @user
+    @wiki.update_attributes!(body: '2222', user: @different_user)
+    @wiki.update_attributes!(body: '3333', user: @user)
+    @wiki.update_attributes!(body: '4444', user: @different_user)
+
+    @wiki.revert_to_version!(2, users(:purple))
+    assert_equal '2222', @wiki.body,  "should revert wiki body"
+    assert_equal 2, @wiki.versions(true).size, "should delete all newer versions"
+    assert_equal '2222', @wiki.versions.find_by_version(2).body, "should keep version 2"
+  end
+
+  private
+
+  def assert_no_new_versions_on_empty_body(initial_body)
+    @wiki = Wiki.new
+    @wiki.update_attributes!(body: initial_body, user: @user)
+
+    assert_latest_body @wiki, initial_body
+    assert_latest_body_html @wiki, ''
+    assert_latest_raw_structure @wiki, wiki_raw_structure_for_n_byte_body(0)
+
+    #
+    # save from different user
+    #
+    assert_no_difference '@wiki.versions.size' do
+      @wiki.update_attributes!(body: 'oi', user: @different_user)
+    end
+    assert_latest_body @wiki, 'oi'
+
+    #
+    # save from same user
+    #
+    @wiki = Wiki.new
+    @wiki.update_attributes!(body: initial_body, user: @user)
+    assert_no_difference '@wiki.versions.size' do
+      @wiki.update_attributes!(body: 'oi', user: @user)
+    end
+    assert_latest_body @wiki, 'oi'
+  end
+
 end

--- a/test/unit/wiki/versioning_test.rb
+++ b/test/unit/wiki/versioning_test.rb
@@ -33,12 +33,11 @@ class Wiki::VersioningTest < ActiveSupport::TestCase
 
   def test_same_body_same_version
     assert_difference '@wiki.versions.size' do
-      @wiki.update_attributes!(body: 'hi', user: @user)
-      @wiki.update_attributes!(body: 'hi', user: @different_user)
+      @wiki.update_section!(:document, @user, nil, 'hi')
+      @wiki.update_section!(:document, @different_user, nil, 'hi')
     end
     assert_equal 1, @wiki.version
-    # FIXME: prevent version take over
-    assert_equal @different_user, @wiki.versions.last.user
+    assert_equal @user, @wiki.versions.last.user
   end
 
   def test_initial_empty_body

--- a/test/unit/wiki_test.rb
+++ b/test/unit/wiki_test.rb
@@ -1,11 +1,5 @@
 require_relative 'test_helper'
 
-#  require File.dirname(__FILE__) + '/wiki/locking_test.rb'
-#  require File.dirname(__FILE__) + '/wiki/rendering_test.rb'
-#  require File.dirname(__FILE__) + '/wiki/saving_test.rb'
-#  require File.dirname(__FILE__) + '/wiki/versioning_test.rb'
-#  require File.dirname(__FILE__) + '/wiki/preview_test.rb'
-
 class WikiTest < ActiveSupport::TestCase
   fixtures :users, :wikis
 
@@ -13,52 +7,6 @@ class WikiTest < ActiveSupport::TestCase
     @user = users(:blue)
     @different_user = users(:red)
   end
-
-  def self.raw_structure_for_n_byte_body(n)
-    {
-      name: nil,
-      children: [],
-      start_index: 0,
-      end_index: n - 1,
-      heading_level: 0
-    }
-  end
-
-  def self.should_have_latest_body body
-    should "have the latest body" do
-      assert_equal body, @wiki.body
-    end
-
-    should "have the latest body for its most recent version" do
-      assert_equal body, @wiki.versions.last.body
-    end
-  end
-
-  def self.should_have_latest_body_html body_html
-    should "have the latest body_html" do
-      assert_equal body_html, @wiki.body_html
-    end
-
-    should "have the latest body_html for its most recent version" do
-      assert_equal body_html, @wiki.versions.last.body_html
-    end
-  end
-
-  def self.should_have_latest_raw_structure raw_structure
-    should "have the latest raw_structure" do
-      assert_equal raw_structure, @wiki.raw_structure
-    end
-
-    should "have the latest raw_structure for its most recent version" do
-      assert_equal raw_structure, @wiki.versions.last.raw_structure
-    end
-  end
-
-  #    include Wiki::LockingTest
-  #    include Wiki::RenderingTest
-  #    include Wiki::VersioningTest
-  #    include Wiki::SavingTest
-  #    include Wiki::PreviewTest
 
   def test_wiki_associations
     assert(check_associations(Wiki))


### PR DESCRIPTION
This is an attempt to fix the failing test for #310.

One test was failing because the version setup did not work anymore. Instead of 6 versions it would create 5 as it tried to create two versions as the same user.

I also rewrote a different test which i used to track the problem down.

I also rewrote Wiki#create_new_version? a bit. It still does the same.
I found the old code hard to grasp - i hope this is a bit more clear.