### PR TITLE
prevent duplicate asset upload

### DIFF
--- a/app/views/common/_asset_upload.html.haml
+++ b/app/views/common/_asset_upload.html.haml
@@ -9,7 +9,6 @@
     %p= :or.t
     #file-select.upload.btn.btn-primary.hook
       %input#upload-input.file.handler{type:"file",
-        name: "our-file",
         multiple: local_assigns[:single] ? false : "multiple"}
         = :select_files.t
 


### PR DESCRIPTION
assigning a name to the upload-input handler will also submit the file
as a parameter for the given key. We add the file to the upload as the
`asset[uploaded_file]` with javascript so we end up uploading it for two
destinct keys and thus uploading it twice. :open_mouth: