### PR TITLE
remove the notification cron tasks

### DIFF
--- a/app/controllers/cron_controller.rb
+++ b/app/controllers/cron_controller.rb
@@ -14,10 +14,6 @@ class CronController < ActionController::Base
 
   def run
     case params[:id]
-    when 'notices_send'
-      PageHistory.send_single_pending_notifications
-    when 'notices_send_digests'
-      PageHistory.send_digest_pending_notifications
     when 'tracking_update_hourlies'
       Tracking::Page.process
     when 'tracking_update_dailies'

--- a/config/misc/schedule.rb
+++ b/config/misc/schedule.rb
@@ -24,14 +24,6 @@ set :host, ENV['RAILS_ENV'] === 'development' ?
 
 job_type :curl, 'curl -L -XPOST http://:host/do/cron/run/:task'
 
-every 5.minutes do
-  curl 'notices_send'
-end
-
-every 1.hour, :at => '0:20' do
-  curl 'notices_send_digests'
-end
-
 every 1.hour, :at => '0:30' do
   curl 'tracking_update_hourlies'
 end


### PR DESCRIPTION
We did not send them for a while and now we have a huge backlog.
So processing the backlog with the old routines has become impossible.

We used to load all page_histories into memory that had no notification send
and then process them. Currently these are > 1,000,000 records. So it eats
all mem and overwhelms the server.