### PR TITLE
Less noisy page notifications at dashboard page

### DIFF
--- a/app/models/notice/page_update_notice.rb
+++ b/app/models/notice/page_update_notice.rb
@@ -1,7 +1,7 @@
 class PageUpdateNotice < PageNotice
 
   def display_title
-    I18n.t("page_updated", data).html_safe
+    I18n.t(:page_updated, data).html_safe
   end
 
   def display_body_as_quote?
@@ -13,7 +13,7 @@ class PageUpdateNotice < PageNotice
   end
 
   def display_label
-    I18n.t "page_update"
+    I18n.t :page_update
   end
 
 end

--- a/app/models/user_extension/pages.rb
+++ b/app/models/user_extension/pages.rb
@@ -171,7 +171,13 @@ module UserExtension::Pages
       page.updated_at = now
       page.updated_by = self
       page.user_participations.where(watch: true).each do |part|
-        PageUpdateNotice.create!(user_id: part.user_id, page: page, from: self)
+        notices = PageUpdateNotice.for_page(page).where(dismissed: false, user_id: part.user_id)
+          .select { |notice| notice.data[:from] == self.name }
+        if notices.any?
+          notices.each &:touch
+        else
+          PageUpdateNotice.create!(user_id: part.user_id, page: page, from: self)
+        end
       end
     end
   end

--- a/test/unit/notice/page_update_notice_test.rb
+++ b/test/unit/notice/page_update_notice_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+class PageUpdateNoticeTest < ActiveSupport::TestCase
+  fixtures :users
+
+  def setup
+    @blue, @orange = users(:blue), users(:orange)
+    create_page_for_user @blue
+  end
+
+  def teardown
+    @page.destroy if @page
+  end
+
+  def test_simple_page_update_displays_notice_for_each_watcher
+    assert_difference 'PageUpdateNotice.count' do
+      @page.add_post @blue, { body: 'comment' }
+    end
+    Notice.last.dismiss!
+
+    watch_page @orange, @page
+    assert_difference 'PageUpdateNotice.count', 2 do
+      @page.add_post @orange, { body: 'comment' }
+    end
+  end
+
+  def test_multiply_updates_by_one_user_updates_timestamp_of_notice
+    old_notice = nil
+
+    assert_difference 'PageUpdateNotice.count' do
+      @page.add_post @blue, { body: 'comment1' }
+      old_notice = Notice.last
+      # miliseconds are ignored during database retrive?!
+      sleep(1)
+      @page.add_post @blue, { body: 'comment2' }
+    end
+
+    assert_not_equal old_notice.updated_at, Notice.last.updated_at
+  end
+
+  def test_multiply_updates_by_many_users_create_just_one_notice
+    watch_page @orange, @page
+    # each user recieves notification for the first page update
+    assert_difference 'PageUpdateNotice.count', 4 do
+      @page.add_post @blue, { body: 'comment1' }
+      @page.add_post @orange, { body: 'comment2' }
+    end
+
+    # but not for the second from same user
+    assert_no_difference 'PageUpdateNotice.count' do
+      @page.add_post @blue, { body: 'comment1' }
+      @page.add_post @orange, { body: 'comment2' }
+    end
+  end
+
+  def test_right_title_for_single_update
+    @page.add_post @blue, { body: 'comment' }
+    title = I18n.t("page_updated", { from: @blue.name, page_title: @page.title }).html_safe
+
+    assert_equal title, Notice.last.display_title
+  end
+
+  def test_right_title_for_multiply_updates_by_one_user
+    @page.add_post @blue, { body: 'comment1' }
+    @page.add_post @blue, { body: 'comment2' }
+    title = I18n.t(:page_updated, { from: @blue.name, page_title: @page.title }).html_safe
+
+    assert_equal title, Notice.last.display_title
+  end
+
+  private
+
+  def create_page_for_user(owner)
+    @page = DiscussionPage.create!({
+      name: "#{owner.login}_page_#{Time.now.to_i}",
+      title: "owned by #{owner.login}",
+      summary: 'Test page for cool users',
+      owner: owner,
+      user: owner
+    })
+
+    watch_page owner, @page
+  end
+
+  def watch_page(user, page)
+    page.add user, watch: true
+    page.save
+  end
+
+end


### PR DESCRIPTION
Hi!
This patch aims to reduce notifications that shown at user dashboard page.

We won't create a new one if there is already similar notification for page update (similar means it  that same page was update by same user), but update it's timestamp only.

References at labs:
Issue: #9415
Link: https://labs.riseup.net/code/issues/9415
Issue: #9738
Link: https://labs.riseup.net/code/issues/9738

This might me just only the first part of featured notifications noise reducing plan.
At least from personal perspective I see no sense to show notification for pages updates by myself.

Another one proposal was related to special notice title in case if one page was updated by a few persons. This is tricky, because currently track only the notice owner user, so title like:
"user **red** and **5** other people have updated the page 'cool page'"
requires additional counter or sql select that might drain performance..
It is also not clear how to dismiss such "multi user" notice.
Maybe new special type?
Any ideas?

Thanks!