### PR TITLE
Use InnoDB for all tables but page_terms

### DIFF
--- a/app/controllers/common/application/tracking.rb
+++ b/app/controllers/common/application/tracking.rb
@@ -10,7 +10,7 @@ module Common::Application::Tracking
       group: @group,
       user: @user,
       action: :view
-    ::Tracking::Page.insert_delayed options
+    ::Tracking::Page.insert options
   end
 
 end

--- a/app/controllers/pages/before_filters.rb
+++ b/app/controllers/pages/before_filters.rb
@@ -113,7 +113,7 @@ module Pages::BeforeFilters
     group = current_site.tracking? && @group
     group ||= current_site.tracking? && @page.owner.is_a?(Group) && @page.owner
     user  = current_site.tracking? && @page.owner.is_a?(User) && @page.owner
-    Tracking::Page.insert_delayed(
+    Tracking::Page.insert(
       page: @page, current_user: current_user, action: action,
       group: group, user: user
     )

--- a/app/models/tracking/page.rb
+++ b/app/models/tracking/page.rb
@@ -13,11 +13,17 @@ class Tracking::Page < ActiveRecord::Base
   # :page         - page that this happened on
   # :group        - group context
   # :user         - user context
-  def self.insert_delayed(things={})
+  #
+  # This used to use "INSERT DELAYED" - however this only works with MyISAM
+  # and the docs say:
+  #   Note that INSERT DELAYED is slower than a normal INSERT if the table
+  #   is not otherwise in use.
+  # So it very much looks like premature optimization.
+  #
+  def self.insert(things={})
     return false if things.empty?
-    delayed = Rails.env.test? ? '' : 'DELAYED' # don't delay if testing
     execute(%(
-      INSERT #{delayed} INTO trackings(current_user_id, page_id, group_id, user_id, views, edits, stars, tracked_at)
+      INSERT INTO trackings(current_user_id, page_id, group_id, user_id, views, edits, stars, tracked_at)
       VALUES (#{values_for_tracking(things).join(', ')})
     ))
     true

--- a/db/migrate/20150908105227_convert_to_innodb.rb
+++ b/db/migrate/20150908105227_convert_to_innodb.rb
@@ -1,0 +1,27 @@
+class ConvertToInnodb < ActiveRecord::Migration
+  #
+  # InnoDB allows us to perform non blocking backups with transactions.
+  #
+  # So we convert all the tables that remained as MyISAM tables to
+  # InnoDB except page_terms which need the full text search capacities
+  # that InnoDB only gained with mysql 5.6. (we're still on 5.5).
+  #
+  # trackings were actively using "INSERT DELAYED" which also is
+  # MyISAM specific - but will be removed in this commit as well.
+  #
+  # The other tables just happen to still be MyISAM in production
+  # because it used to be the default.
+  #
+  def self.up
+    execute("ALTER TABLE trackings ENGINE=InnoDB")
+    execute("ALTER TABLE migrations_info ENGINE=InnoDB")
+    execute("ALTER TABLE schema_migrations ENGINE=InnoDB")
+    if ActiveRecord::Base.connection.table_exists? 'plugin_schema_info'
+      execute("ALTER TABLE plugin_schema_info ENGINE=InnoDB")
+    end
+  end
+
+  def self.down
+    execute("ALTER TABLE trackings ENGINE=MyISAM")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150810092223) do
+ActiveRecord::Schema.define(:version => 20150908105227) do
 
   create_table "activities", :force => true do |t|
     t.integer  "subject_id"
@@ -827,8 +827,6 @@ ActiveRecord::Schema.define(:version => 20150810092223) do
     t.boolean  "stars"
     t.integer  "user_id"
   end
-
-  execute "ALTER TABLE trackings ENGINE = MyISAM"
 
   create_table "user_participations", :force => true do |t|
     t.integer  "page_id"

--- a/lib/extends/active_record.rb
+++ b/lib/extends/active_record.rb
@@ -149,7 +149,7 @@ end
 
 #
 # What is going on here!?
-# Crabgrass requires MyISAM for certain tables and the ability to add fulltext
+# Crabgrass requires MyISAM for the page_terms and the ability to add fulltext
 # indexes. Additionally, since we are tied to mysql, we might as well be able
 # to use it properly and specify the index length.
 #
@@ -168,10 +168,6 @@ module ActiveRecord
   class SchemaDumper #:nodoc:
     # modifies index support for MySQL full text indexes
     def indexes(table, stream)
-      if table == 'page_views' or table == 'trackings'
-        stream.puts %(  execute "ALTER TABLE #{table} ENGINE = MyISAM")
-        stream.puts
-      end
       indexes = @connection.indexes(table)
       indexes.each do |index|
         if index.name =~ /fulltext/ and @connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)

--- a/test/unit/pagination_test.rb
+++ b/test/unit/pagination_test.rb
@@ -18,7 +18,7 @@ class PaginationTest < ActiveSupport::TestCase
       # last page gets only 1 view
       # lets us test that pagination sorts them properly
       (all_pages.size - index).times do
-        Tracking::Page.insert_delayed(current_user: user,
+        Tracking::Page.insert(current_user: user,
           user: user,
           group: group,
           page: page,

--- a/test/unit/tracking/page_test.rb
+++ b/test/unit/tracking/page_test.rb
@@ -14,11 +14,11 @@ class Tracking::PageTest < ActiveSupport::TestCase
     group = groups(:rainbow)
     assert membership = user.memberships.find_by_group_id(group.id)
     assert_difference('Membership.find(%d).total_visits'%membership.id) do
-      Tracking::Page.insert_delayed(current_user: user, group: group)
+      Tracking::Page.insert(current_user: user, group: group)
       Tracking::Page.process
     end
     assert_difference('Membership.find(%d).total_visits'%membership.id) do
-      Tracking::Page.insert_delayed(current_user: user.id, group: group.id)
+      Tracking::Page.insert(current_user: user.id, group: group.id)
       Tracking::Page.process
     end
   end
@@ -28,7 +28,7 @@ class Tracking::PageTest < ActiveSupport::TestCase
     user = users(:orange)
 
     assert_difference 'Tracking::Page.count', 3 do
-      3.times { Tracking::Page.insert_delayed(current_user: current_user, user: user) }
+      3.times { Tracking::Page.insert(current_user: current_user, user: user) }
     end
     assert_difference 'Tracking::Page.count', -3 do
       Tracking::Page.process
@@ -76,9 +76,9 @@ class Tracking::PageTest < ActiveSupport::TestCase
     group1 = groups(:rainbow)
     group2 = groups(:animals)
     group3 = groups(:recent_group)
-    1.times { Tracking::Page.insert_delayed(current_user: user, group: group3) }
-    2.times { Tracking::Page.insert_delayed(current_user: user, group: group2) }
-    3.times { Tracking::Page.insert_delayed(current_user: user, group: group1) }
+    1.times { Tracking::Page.insert(current_user: user, group: group3) }
+    2.times { Tracking::Page.insert(current_user: user, group: group2) }
+    3.times { Tracking::Page.insert(current_user: user, group: group1) }
     Tracking::Page.process
     assert_equal [group1, group2, group3], user.primary_groups.most_active[0..2]
   end
@@ -87,7 +87,7 @@ class Tracking::PageTest < ActiveSupport::TestCase
 
   # Insert delayed is not delaysed for testing so this should not cause problems.
   def assert_tracking(user, group, page, action, time=nil)
-    Tracking::Page.insert_delayed(current_user: user, group: group, page: page, action: action, time: time)
+    Tracking::Page.insert(current_user: user, group: group, page: page, action: action, time: time)
     track=Tracking::Page.last
     assert_equal track.current_user_id, user.id, "User not stored correctly in Tracking"
     assert_equal track.group_id, group.id, "Group not stored correctly in Tracking"


### PR DESCRIPTION
InnoDB allows us to perform non blocking backups with transactions.

So we convert all the tables that remained as MyISAM tables to
InnoDB except page_terms which need the full text search capacities
that InnoDB only gained with mysql 5.6. (we're still on 5.5).

trackings were actively using "INSERT DELAYED" which also is
MyISAM specific - but will be removed in this commit as well.
The mysql docs say:

> Note that INSERT DELAYED is slower than a normal INSERT if the table
> is not otherwise in use.

So it very much looks like premature optimization.

The other tables just happen to still be MyISAM in production