### PR TITLE
default link color that can be used in headings

### DIFF
--- a/extensions/themes/riseup/init.rb
+++ b/extensions/themes/riseup/init.rb
@@ -16,6 +16,13 @@ define_theme(parent: 'default') {
     }
   }
 
+  link {
+    # this is the color of the menu background in the banner navigation.
+    # (banner background with a dark overlay)
+    # It works both for normal fonts and for headings
+    standard_color "#2a5183"
+  }
+
 }
 
 style %{


### PR DESCRIPTION
:art: The default link color of #00e is very intense. It looks bad in
large headings because it breaks the overall color scheme.

This color is taken from the menu background in the banner navigation.
(banner background with a dark overlay)

It works both for normal fonts and for headings:
( I turned the heading into a link for testing - but that is not what i am planning - no worries. :sweat_smile: )

![screenshot with page title turned link](https://cloud.githubusercontent.com/assets/102902/9757680/49f8baf6-56e2-11e5-877b-b4f49e72345f.png)