### PR TITLE
Group tasks by pages on the "my tasks" view

### DIFF
--- a/app/controllers/me/tasks_controller.rb
+++ b/app/controllers/me/tasks_controller.rb
@@ -1,14 +1,18 @@
 class Me::TasksController < Me::BaseController
 
   def index
-    if completed?
-      @tasks = current_user.tasks.completed.order('updated_at DESC')
-    else
-      @tasks = current_user.tasks.pending.order('updated_at DESC').limit(200)
-    end
+    @tasks = tasks_for_view.order('updated_at DESC').limit(200)
   end
 
   protected
+
+  def tasks_for_view
+    current_user.tasks.send(view)
+  end
+
+  def view
+    completed? ? :completed : :pending
+  end
 
   def completed?
     params[:view] == 'completed'

--- a/app/controllers/me/tasks_controller.rb
+++ b/app/controllers/me/tasks_controller.rb
@@ -1,10 +1,14 @@
 class Me::TasksController < Me::BaseController
 
   def index
-    @tasks = tasks_for_view.order('updated_at DESC').limit(200)
+    @pages = pages_with_tasks.order('pages.updated_at DESC').limit(20)
   end
 
   protected
+
+  def pages_with_tasks
+    TaskListPage.with_tasks tasks_for_view
+  end
 
   def tasks_for_view
     current_user.tasks.send(view)

--- a/app/views/me/tasks/_page.html.haml
+++ b/app/views/me/tasks/_page.html.haml
@@ -1,0 +1,9 @@
+.panel.panel-default
+  .panel-heading
+    %h2
+      = link_to page.title, page_url(page)
+      %small=page.owner.try.display_name
+    %p= page.summary
+
+  %ul.list-group
+    = render page.tasks

--- a/app/views/me/tasks/index.html.haml
+++ b/app/views/me/tasks/index.html.haml
@@ -1,2 +1,1 @@
-%ul.list-group.stripe
-  = render @tasks
+= render partial: 'me/tasks/page', collection: @pages

--- a/extensions/pages/task_list_page/app/models/task_list_page.rb
+++ b/extensions/pages/task_list_page/app/models/task_list_page.rb
@@ -13,5 +13,11 @@ class TaskListPage < Page
     # no need to instantiate all the tasks. Using sql to build the string.
     tasks.pluck('CONCAT(name,"\t",description)').join "\n"
   end
+
+  # Fetch the pages that for the given task_ids and include the tasks
+  # Now page.tasks will return only the tasks that were in task_ids \o/.
+  def self.with_tasks(task_ids)
+    includes(:tasks).where(tasks: {id: task_ids})
+  end
 end
 

--- a/extensions/pages/task_list_page/test/unit/task_list_page_test.rb
+++ b/extensions/pages/task_list_page/test/unit/task_list_page_test.rb
@@ -15,6 +15,16 @@ class TaskListPageTest < ActiveSupport::TestCase
     assert_nil Task.find_by_id(id), 'deleting the page should delete the tasks'
   end
 
+  def test_with_tasks_fetches_right_pages
+    assert_equal 1, TaskListPage.with_tasks([1,2]).count
+    assert_equal 2, TaskListPage.with_tasks([1,4]).count
+  end
+
+  def test_with_tasks_includes_right_tasks
+    pages = TaskListPage.with_tasks([1,2,5,6])
+    assert_equal [tasks(:task1), tasks(:task2)], pages.first.tasks
+  end
+
   def expected_body_terms
     expected_body_terms = [1,2,3]
       .map {|n| "task#{n}\ttask#{n} description"}


### PR DESCRIPTION
Task Summary rework... Tasks often only make sense in the context of their pages. It's nice to have short task titles such as 'cleanup' without having to specify the context. However we currently only display the task name - not the page name in my tasks. So I propose to group tasks by pages instead.