### PR TITLE
bugfix: ordered list numbers in wikis

### DIFF
--- a/app/stylesheets/ui/_wiki.scss
+++ b/app/stylesheets/ui/_wiki.scss
@@ -100,10 +100,15 @@ article {
     }
 
     ul, ol {
+      padding-left: 1em;
+      margin-left: 0.5em;
+    }
+
+    ul {
       list-style: disc outside none;
       padding-left: 1em;
       margin-left: 0.5em;
-      ul, ol {
+      ul {
         list-style: circle outside none;
       }
     }


### PR DESCRIPTION
They were not displayed because we set list-style both for
ul and ol. Ordered lists should have their own list style though.