### PR TITLE
hide deleted pages and their tasks in me/tasks

### DIFF
--- a/app/controllers/me/tasks_controller.rb
+++ b/app/controllers/me/tasks_controller.rb
@@ -1,7 +1,10 @@
 class Me::TasksController < Me::BaseController
 
   def index
-    @pages = pages_with_tasks.order('pages.updated_at DESC').limit(20)
+    @pages = pages_with_tasks
+      .not_deleted
+      .order('pages.updated_at DESC')
+      .limit(20)
   end
 
   protected

--- a/test/fixtures/task_participations.yml
+++ b/test/fixtures/task_participations.yml
@@ -7,20 +7,15 @@ blue_5:
   user_id: 4
   task_id: 5
   assigned: true
-  
-blue_6:
-  user_id: 4
-  task_id: 6
-  assigned: true
-  
+
 quentin_6:
   user_id: 1
   task_id: 6
   watching: true
-  
+
 gerrard_6:
   user_id: 2
   task_id: 6
   waiting: true
-  
+
 

--- a/test/integration/task_overview_test.rb
+++ b/test/integration/task_overview_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'javascript_integration_test'
+
+class TaskOverviewTest < JavascriptIntegrationTest
+  fixtures :all
+
+  def test_list_only_pages_with_assigned_tasks
+    login users(:blue)
+    visit '/me/tasks'
+    assert_selector 'h2', text: 'another task list'
+    assert_content 'task4'
+    assert_no_content 'task6'
+    assert_no_selector 'h2', text: 'a task list'
+    assert_no_content 'task1'
+  end
+
+  def test_no_deleted_pages
+    pages(:tasklist2).delete
+    login users(:blue)
+    visit '/me/tasks'
+    assert_no_selector 'h2', text: 'another task list'
+    assert_no_content 'task4'
+  end
+
+
+
+end


### PR DESCRIPTION
Also an initial integration test to make sure the right tasks and
pages are displayed