### PR TITLE
namespace Activity and remove from autoload_path

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -35,7 +35,7 @@ class SessionController < ApplicationController
 
       # replace this:
       #current_site.add_user!(current_user)
-      #UnreadActivity.create(:user => current_user)
+      #Activity::Unread.create(:user => current_user)
       # with
       # hook(:successful_login)
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -28,7 +28,6 @@
 # related_id and extra are used for generic storage and association, whatever
 # the subclass wants to use it for.
 #
-
 class Activity < ActiveRecord::Base
 
   # activity access (relative to self.subject):
@@ -138,10 +137,10 @@ class Activity < ActiveRecord::Base
     [ "(subject_type = 'User'  AND subject_id = ?) OR
        (subject_type = 'User'  AND subject_id IN (?) AND access != ?) OR
        (subject_type = 'Group' AND subject_id IN (?)) ",
-      user.id,
-      other_users_ids_list,
-      Activity::PRIVATE,
-      user.all_group_id_cache]
+       user.id,
+       other_users_ids_list,
+       Activity::PRIVATE,
+       user.all_group_id_cache]
   end
 
   # for user's landing page
@@ -157,8 +156,8 @@ class Activity < ActiveRecord::Base
   def self.for_user(user, current_user)
     if (current_user and current_user.friend_of?(user) or current_user == user)
       restricted = Activity::PRIVATE
-    # elsif current_user and current_user.peer_of?(user)
-    #   restricted = Activity::DEFAULT
+      # elsif current_user and current_user.peer_of?(user)
+      #   restricted = Activity::DEFAULT
     else
       restricted = Activity::DEFAULT
     end
@@ -225,4 +224,3 @@ class Activity < ActiveRecord::Base
   end
 
 end
-

--- a/app/models/activity/friend.rb
+++ b/app/models/activity/friend.rb
@@ -1,4 +1,4 @@
-class FriendActivity < Activity
+class Activity::Friend < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_format_of :item_type, with: /User/
@@ -35,16 +35,16 @@ class FriendActivity < Activity
             other_user: user_span(:other_user))
   end
 
-  # Warning: Do not use self.class or even FriendActivity here...
+  # Warning: Do not use self.class or even Activity::Friend here...
   # Why? It seems the scope of self is kept in that case.
   # So activity.twin.twin would always return nil because it tries to
   # fullfill both conditions (those for the twin and for the twin of that twin)
   # at the same time.
   # UPGRADE: Check if this is fixed
   def twin
-    Activity.where(type: self.type).
-      where(subject_id: item_id, subject_type: 'User').
-      where(item_id: subject_id, item_type: 'User')
+    Activity.where type: 'Friend',
+      subject_id: item_id, subject_type: 'User',
+      item_id: subject_id, item_type: 'User'
   end
 
   def icon

--- a/app/models/activity/group_created.rb
+++ b/app/models/activity/group_created.rb
@@ -1,4 +1,4 @@
-class GroupCreatedActivity < Activity
+class Activity::GroupCreated < Activity
 
   validates_format_of :subject_type, with: /Group/
   validates_presence_of :subject_id

--- a/app/models/activity/group_destroyed.rb
+++ b/app/models/activity/group_destroyed.rb
@@ -1,4 +1,4 @@
-class GroupDestroyedActivity < Activity
+class Activity::GroupDestroyed < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_presence_of :subject_id

--- a/app/models/activity/group_gained_user.rb
+++ b/app/models/activity/group_gained_user.rb
@@ -1,4 +1,4 @@
-class GroupGainedUserActivity < Activity
+class Activity::GroupGainedUser < Activity
 
   validates_format_of :subject_type, with: /Group/
   validates_format_of :item_type, with: /User/

--- a/app/models/activity/group_lost_user.rb
+++ b/app/models/activity/group_lost_user.rb
@@ -1,4 +1,5 @@
-class GroupLostUserActivity < GroupGainedUserActivity
+class Activity::GroupLostUser < Activity::GroupGainedUser
+
   def description(view=nil)
     I18n.t(:activity_user_left_group,
         user: user_span(:user),

--- a/app/models/activity/message_sent.rb
+++ b/app/models/activity/message_sent.rb
@@ -1,4 +1,4 @@
-class PrivatePostActivity < Activity
+class Activity::MessageSent < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_presence_of :subject_id

--- a/app/models/activity/message_wall.rb
+++ b/app/models/activity/message_wall.rb
@@ -1,4 +1,4 @@
-class MessageWallActivity < Activity
+class Activity::MessageWall < Activity
   include ActionView::Helpers::TagHelper
 
   validates_format_of :subject_type, with: /User/

--- a/app/models/activity/twinkled.rb
+++ b/app/models/activity/twinkled.rb
@@ -1,4 +1,4 @@
-class TwinkledActivity < Activity
+class Activity::Twinkled < Activity
   include ActionView::Helpers::TagHelper
 
   validates_format_of :subject_type, with: /User/

--- a/app/models/activity/unread.rb
+++ b/app/models/activity/unread.rb
@@ -1,4 +1,4 @@
-class UnreadActivity < Activity
+class Activity::Unread < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_presence_of :subject_id
@@ -22,12 +22,12 @@ class UnreadActivity < Activity
     self.unread_count = user.relationships.sum('unread_count') || 0
   end
 
-  # We want to delete the other UnreadActivities even if we don't pass
+  # We want to delete the other Activity::Unread even if we don't pass
   # validations, because if there are no unread messages, we want no
-  # UnreadActivities.
+  # Activity.
   before_validation :destroy_twins, on: :create
   def destroy_twins
-    UnreadActivity.destroy_all 'subject_id = %s' % user.id
+    self.class.destroy_all 'subject_id = %s' % user.id
   end
 
   public

--- a/app/models/activity/user_created_group.rb
+++ b/app/models/activity/user_created_group.rb
@@ -1,4 +1,4 @@
-class UserCreatedGroupActivity < Activity
+class Activity::UserCreatedGroup < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_format_of :item_type, with: /Group/

--- a/app/models/activity/user_destroyed.rb
+++ b/app/models/activity/user_destroyed.rb
@@ -1,4 +1,4 @@
-class UserDestroyedActivity < Activity
+class Activity::UserDestroyed < Activity
 
   validates_format_of :subject_type, with: /User/
   validates_presence_of :subject_id

--- a/app/models/activity/user_joined_group.rb
+++ b/app/models/activity/user_joined_group.rb
@@ -1,4 +1,5 @@
-class UserProposedToDestroyGroupActivity < Activity
+class Activity::UserJoinedGroup < Activity
+
   validates_format_of :subject_type, with: /User/
   validates_format_of :item_type, with: /Group/
   validates_presence_of :subject_id
@@ -16,16 +17,14 @@ class UserProposedToDestroyGroupActivity < Activity
 
 
   def description(view=nil)
-    I18n.t(:request_to_destroy_our_group_description,
+    I18n.t(:activity_user_joined_group,
               user: user_span(:user),
               group_type: group_class(:group),
               group: group_span(:group))
   end
 
   def icon
-    'minus'
+    'membership_add'
   end
 
-
 end
-

--- a/app/models/activity/user_joined_site.rb
+++ b/app/models/activity/user_joined_site.rb
@@ -1,4 +1,4 @@
-class UserJoinedSiteActivity < UserJoinedGroupActivity
+class Activity::UserJoinedSite < Activity::UserJoinedGroup
 
   def description(view=nil)
     I18n.t(:activity_user_joined_site,

--- a/app/models/activity/user_left_group.rb
+++ b/app/models/activity/user_left_group.rb
@@ -1,4 +1,4 @@
-class UserLeftGroupActivity < UserJoinedGroupActivity
+class Activity::UserLeftGroup < Activity::UserJoinedGroup
   def description(view=nil)
     I18n.t(:activity_user_left_group,
              user: user_span(:user),

--- a/app/models/activity/user_left_site.rb
+++ b/app/models/activity/user_left_site.rb
@@ -1,4 +1,4 @@
-class UserLeftSiteActivity < UserLeftGroupActivity
+class Activity::UserLeftSite < Activity::UserLeftGroup
   def description(view=nil)
     I18n.t(:activity_user_left_site,
          user: user_span(:user),

--- a/app/models/activity/user_proposed_to_destroy_group.rb
+++ b/app/models/activity/user_proposed_to_destroy_group.rb
@@ -1,5 +1,4 @@
-class UserJoinedGroupActivity < Activity
-
+class Activity::UserProposedToDestroyGroup < Activity
   validates_format_of :subject_type, with: /User/
   validates_format_of :item_type, with: /Group/
   validates_presence_of :subject_id
@@ -17,14 +16,16 @@ class UserJoinedGroupActivity < Activity
 
 
   def description(view=nil)
-    I18n.t(:activity_user_joined_group,
+    I18n.t(:request_to_destroy_our_group_description,
               user: user_span(:user),
               group_type: group_class(:group),
               group: group_span(:group))
   end
 
   def icon
-    'membership_add'
+    'minus'
   end
 
+
 end
+

--- a/app/models/discussion/private_post.rb
+++ b/app/models/discussion/private_post.rb
@@ -1,8 +1,9 @@
 class PrivatePost < Post
 
-  has_one :private_post_activity,
+  has_one :activity,
     foreign_key: :related_id,
-    dependent: :delete
+    dependent: :delete,
+    class_name: 'Activity::MessageSent'
 
   def private?
     true

--- a/app/models/tracking/action.rb
+++ b/app/models/tracking/action.rb
@@ -1,11 +1,11 @@
 module Tracking::Action
 
   EVENT_CREATES_ACTIVITIES = {
-    create_group: ['GroupCreatedActivity', 'UserCreatedGroupActivity'],
-    create_membership: ['GroupGainedUserActivity', 'UserJoinedGroupActivity'],
-    destroy_membership: ['GroupLostUserActivity', 'UserLeftGroupActivity'],
-    request_to_destroy_group: ['UserProposedToDestroyGroupActivity'],
-    create_friendship: ['FriendActivity'],
+    create_group: ['Activity::GroupCreated', 'Activity::UserCreatedGroup'],
+    create_membership: ['Activity::GroupGainedUser', 'Activity::UserJoinedGroup'],
+    destroy_membership: ['Activity::GroupLostUser', 'Activity::UserLeftGroup'],
+    request_to_destroy_group: ['Activity::UserProposedToDestroyGroup'],
+    create_friendship: ['Activity::Friend'],
     create_post: ['PageHistory::AddComment'],
     update_post: ['PageHistory::UpdateComment'],
     destroy_post: ['PageHistory::DestroyComment'],

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Crabgrass
     config.autoload_paths << "#{Rails.root}/lib"
     config.autoload_paths << "#{Rails.root}/app/models"
 
-    config.autoload_paths += %w(activity assets associations discussion chat profile poll task requests mailers notice).
+    config.autoload_paths += %w(assets associations discussion chat profile poll task requests mailers notice).
      collect { |dir| "#{Rails.root}/app/models/#{dir}" }
     config.autoload_paths << "#{Rails.root}/app/permissions"
     config.autoload_paths << "#{Rails.root}/app/sweepers"

--- a/db/migrate/20150916094928_change_activity_types.rb
+++ b/db/migrate/20150916094928_change_activity_types.rb
@@ -1,0 +1,15 @@
+class ChangeActivityTypes < ActiveRecord::Migration
+  def up
+    Activity.connection.execute <<-EOSQL
+    UPDATE activities
+    SET type = REPLACE(type, 'Activity', '')
+    EOSQL
+  end
+
+  def down
+    Activity.connection.execute <<-EOSQL
+    UPDATE activities
+    SET type = CONCAT(type, 'Activity')
+    EOSQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150911091551) do
+ActiveRecord::Schema.define(:version => 20150916094928) do
 
   create_table "activities", :force => true do |t|
     t.integer  "subject_id"

--- a/test/fixtures/activities.yml
+++ b/test/fixtures/activities.yml
@@ -2,7 +2,7 @@
 activities_001:
   item_name: gerrard
   subject_name: animals
-  type: GroupCreatedActivity
+  type: GroupCreated
   id: "1"
   subject_type: Group
   subject_id: "2"
@@ -15,7 +15,7 @@ activities_001:
 activities_002:
   item_name: animals
   subject_name: gerrard
-  type: UserCreatedGroupActivity
+  type: UserCreatedGroup
   id: "2"
   subject_type: User
   subject_id: "3"
@@ -28,7 +28,7 @@ activities_002:
 activities_003:
   item_name: animals
   subject_name: gerrard
-  type: UserJoinedGroupActivity
+  type: UserJoinedGroup
   id: "3"
   subject_type: User
   subject_id: "3"
@@ -41,7 +41,7 @@ activities_003:
 activities_004:
   item_name: gerrard
   subject_name: animals
-  type: GroupGainedUserActivity
+  type: GroupGainedUser
   id: "4"
   subject_type: Group
   subject_id: "2"
@@ -54,7 +54,7 @@ activities_004:
 activities_005:
   item_name: animals
   subject_name: blue
-  type: UserJoinedGroupActivity
+  type: UserJoinedGroup
   id: "5"
   subject_type: User
   subject_id: "4"
@@ -67,7 +67,7 @@ activities_005:
 activities_006:
   item_name: blue
   subject_name: animals
-  type: GroupGainedUserActivity
+  type: GroupGainedUser
   id: "6"
   subject_type: Group
   subject_id: "2"
@@ -80,7 +80,7 @@ activities_006:
 activities_007:
   item_name: gerrard
   subject_name: blue
-  type: TwinkledActivity
+  type: Twinkled
   id: "7"
   subject_type: User
   subject_id: "4"
@@ -95,7 +95,7 @@ activities_007:
 activities_008:
   item_name: blue
   subject_name: gerrard
-  type: FriendActivity
+  type: Friend
   id: "8"
   subject_type: User
   subject_id: "3"
@@ -108,7 +108,7 @@ activities_008:
 activities_009:
   item_name: gerrard
   subject_name: blue
-  type: FriendActivity
+  type: Friend
   id: "9"
   subject_type: User
   subject_id: "4"
@@ -121,7 +121,7 @@ activities_009:
 activities_010:
   item_name:
   subject_name: blue
-  type: UserDestroyedActivity
+  type: UserDestroyed
   id: "10"
   subject_type: User
   subject_id: "4"
@@ -134,7 +134,7 @@ activities_010:
 activities_012:
   item_name: gerrard
   subject_name: blue
-  type: MessageWallActivity
+  type: MessageWall
   id: "12"
   subject_type: User
   subject_id: "4"

--- a/test/functional/context_pages_controller_test.rb
+++ b/test/functional/context_pages_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ContextPagesControllerTest < ActionController::TestCase
-  fixtures :users, :pages, :groups
+  fixtures :all
 
   def test_group_page
     login_as users(:blue)

--- a/test/functional/groups/requests_controller_test.rb
+++ b/test/functional/groups/requests_controller_test.rb
@@ -22,7 +22,7 @@ class Groups::RequestsControllerTest < ActionController::TestCase
         get :create, group_id: @group.to_param, type: 'destroy_group'
       end
     assert_response :redirect
-    assert activity = UserProposedToDestroyGroupActivity.last
+    assert activity = Activity::UserProposedToDestroyGroup.last
     assert_equal @user, activity.user
     assert_equal @group, activity.group
   end

--- a/test/unit/group_test.rb
+++ b/test/unit/group_test.rb
@@ -173,7 +173,7 @@ class GroupTest < ActiveSupport::TestCase
     assert_nil page.reload.owner_id
 
     red = users(:red)
-    assert_nil GroupLostUserActivity.for_all(red).find(:first),
+    assert_nil Activity::GroupLostUser.for_all(red).find(:first),
       "there should be no user left group message"
   end
 

--- a/test/unit/tracking/action_test.rb
+++ b/test/unit/tracking/action_test.rb
@@ -3,28 +3,28 @@ require 'test_helper'
 class Tracking::ActionTest < ActiveSupport::TestCase
 
   def test_class_lookup
-    FriendActivity.expects(:create!)
+    Activity::Friend.expects(:create!)
     Tracking::Action.track :create_friendship
   end
 
   def test_key_seed
-    FriendActivity.expects(:create!).with(has_key(:key))
+    Activity::Friend.expects(:create!).with(has_key(:key))
     Tracking::Action.track :create_friendship
   end
 
   def test_hand_over_args
-    FriendActivity.expects(:create!).with(has_key(:user))
+    Activity::Friend.expects(:create!).with(has_key(:user))
     Tracking::Action.track :create_friendship, user: :dummy
   end
 
   def test_filter_args
-    FriendActivity.expects(:create!).with(Not(has_key(:dummy)))
+    Activity::Friend.expects(:create!).with(Not(has_key(:dummy)))
     Tracking::Action.track :create_friendship, dummy: :user
   end
 
   def test_create_multiple_records
-    GroupCreatedActivity.expects(:create!)
-    UserCreatedGroupActivity.expects(:create!)
+    Activity::GroupCreated.expects(:create!)
+    Activity::UserCreatedGroup.expects(:create!)
     Tracking::Action.track :create_group
   end
 end


### PR DESCRIPTION
We used to have app/models/activity in the autoload path and had classes
like FriendActivity < Activity

This conflicts with how rails4 handles class lookup. Plus it clutters the
autoload path and makes it harder to find classes.

Using proper namespaces instead now and I'm about to apply this to all the
different namespace avoiding things like ...Extension. We can use classes
as namespaces as long as we:
* make sure to define things inside the namespace in one line or in a
   class instead of a module block:
  
   ```ruby
     class Activity::Friend < Activity
     # or
     class Activity
       class Friend < ::Activity
   ```
* have names inside the namespaces that do not conflict with global names

The second one is important because if PrivatePost is already loaded and
Activity::PrivatePost is referenced somewhere it will be found as an
constant inside the Object namespace of Activity (since Activity is a class).
So instead of loading Activity::PrivatePost we'll see a warning that global
constant PrivatePost was referenced by Activity::PrivatePost.

So how do we prevent this?
* do not clutter the global namespace
* use more specific names in other namespaces
  -> in this case i am renaming PrivatePostActivity to Activity::MessageSent
  and not Activity::PrivatePost