### PR TITLE
enable `current_site.tracking?` by default.

### DIFF
--- a/app/controllers/pages/before_filters.rb
+++ b/app/controllers/pages/before_filters.rb
@@ -110,9 +110,18 @@ module Pages::BeforeFilters
     end
     return true unless action
 
-    group = current_site.tracking? && @group
-    group ||= current_site.tracking? && @page.owner.is_a?(Group) && @page.owner
-    user  = current_site.tracking? && @page.owner.is_a?(User) && @page.owner
+    group = nil
+    user  = nil
+    if current_site.tracking?
+      if @group
+        group = @group
+      elsif @page.owner_is?(Group)
+        group = @page.owner
+      end
+      if @page.owner_is?(User)
+        user = @page.owner
+      end
+    end
     Tracking::Page.insert(
       page: @page, current_user: current_user, action: action,
       group: group, user: user

--- a/lib/crabgrass/conf.rb
+++ b/lib/crabgrass/conf.rb
@@ -114,7 +114,7 @@ class Conf
     self.default_language  = 'en'
     self.email_sender      = 'robot@$current_host'
     self.email_sender_name = '$site_title ($user_name)'
-    self.tracking          = false
+    self.tracking          = true
     self.evil              = {}
     self.available_page_types = []
     self.enforce_ssl       = false


### PR DESCRIPTION
 the only thing that turning off tracking does is make it so that we can't sort a user's list of groups or users by order of most interactions.

the idea behind making tracking optional is that we might not want to retain information on the behavior of users. but disabling tracking only makes it so that we don't know what the owner of pages were that you have interacted with, but we still record that you interacted with those pages.

so, i think it is a very minor privacy gain to disable tracking, and currently it breaks some core functionality.