### PR TITLE
use delayed job for long running CronController action

### DIFF
--- a/app/controllers/cron_controller.rb
+++ b/app/controllers/cron_controller.rb
@@ -15,7 +15,7 @@ class CronController < ActionController::Base
   def run
     case params[:id]
     when 'tracking_update_hourlies'
-      Tracking::Page.process
+      Tracking::Page.delay.process
     when 'tracking_update_dailies'
       Tracking::Daily.update
     when 'codes_expire'


### PR DESCRIPTION
This way we can respond quickly and still benefit from the already
running instances - in contrast to a rake task.