### PR TITLE
bugfix: redirect url based on request not params

### DIFF
--- a/app/views/session/_login_form.html.haml
+++ b/app/views/session/_login_form.html.haml
@@ -5,8 +5,6 @@
 -# tab focus.
 -#
 
-- redirect_url = params.present? && url_for(params.merge(only_path: true))
-
 .login_form
   = form_tag(login_path, id: "entry") do
     - cache current_language do
@@ -15,7 +13,7 @@
       %div
         %label(for = 'login')= :login_name.t
         %span= link_to :signup_link.t,
-          new_account_path(redirect: redirect_url),
+          new_account_path(redirect: request.original_fullpath),
           class: 'nofocus'
         = text_field_tag 'login', params['login'], id: 'login', tabindex: 1, class: 'form-control'
       %div.password

--- a/test/integration/error_flow_test.rb
+++ b/test/integration/error_flow_test.rb
@@ -22,6 +22,18 @@ class ErrorFlowTest < IntegrationTest
     assert_equal '/me/pages', current_path
   end
 
+  def test_not_found_but_exists
+    visit '/private_group'
+    assert_content 'Not Found'
+    assert_no_content 'private_group'
+    assert_equal '/private_group', current_path
+    fill_in 'login', with: 'blue'
+    fill_in 'password', with: 'blue'
+    click_button :login_button.t
+    assert_content 'private_group'
+    assert_equal '/private_group', current_path
+  end
+
   def test_not_found
     visit '/asdfswera'
     assert_content 'Not Found'


### PR DESCRIPTION
Rebuilding the url may not be possible from params. In particular if
a dispatch controller jumped in and altered the params.

Instead we now use the exact string thatwe started from.