### PR TITLE
use fragment instead of page caching for themes screen.css

### DIFF
--- a/app/views/theme/show.css.erb
+++ b/app/views/theme/show.css.erb
@@ -1,0 +1,3 @@
+<% cache(request.original_fullpath) do %>
+  <%= raw @theme.render_css(@file) %>
+<% end %>


### PR DESCRIPTION
rails 4 drops page caches and it does not work in production right now because
the corresponding apache config settings are missing.