### PR TITLE
use theme cache key

### DIFF
--- a/app/views/theme/show.css.erb
+++ b/app/views/theme/show.css.erb
@@ -1,3 +1,3 @@
-<% cache(request.original_fullpath) do %>
+<% cache([@theme.cache_key, @file]) do %>
   <%= raw @theme.render_css(@file) %>
 <% end %>


### PR DESCRIPTION
before we only used the url as a cache key. This would have
prevented the key from changing on theme updates. Instead we now
use the cache_key of the theme.