### PR TITLE
make use of 304 - not modified for css

### DIFF
--- a/app/controllers/theme_controller.rb
+++ b/app/controllers/theme_controller.rb
@@ -23,7 +23,9 @@ class ThemeController < ApplicationController
   caches_page :show, if: Proc.new {|ctrl| ctrl.cache_css}
 
   def show
-    render :show, content_type: 'text/css', formats: [:css]
+    if stale?(@theme, file: @file)
+      render :show, content_type: 'text/css', formats: [:css]
+    end
   rescue Sass::SyntaxError => exc
     self.cache_css = false
     render text: @theme.error_response(exc)

--- a/app/views/theme/show.css.erb
+++ b/app/views/theme/show.css.erb
@@ -1,3 +1,3 @@
-<% cache(request.original_fullpath) do %>
+<% cache([@theme.cache_key, @file]) do %>
   <%= raw @theme.render_css(@file) %>
 <% end %>

--- a/vendor/crabgrass_plugins/crabgrass_theme/lib/crabgrass/theme/cache.rb
+++ b/vendor/crabgrass_plugins/crabgrass_theme/lib/crabgrass/theme/cache.rb
@@ -11,8 +11,12 @@ module Crabgrass::Theme::Cache
     FileUtils.rm_r(cached, secure: true) if File.exist? cached
   end
 
+  def updated_at
+    config_updated_at.utc
+  end
+
   def cache_key
-    "theme/#{name}-#{config_updated_at.utc.to_s(:number)}"
+    "theme/#{name}-#{updated_at.to_s(:number)}"
   end
 
   private


### PR DESCRIPTION
Also use proper caching key.

Now we use them all:
* page cache - it's the fastest and makes it so only a small percentage of the css requests end up hitting the rails app.
* stale? - if the theme is the same the browser fetched the last time - and if it's the same file - just return a 304.
* fragment caching - for the first time visiting browsers cache the css in fragment cache.