### PR TITLE
enough padding for numbered lists in wikis

### DIFF
--- a/app/controllers/theme_controller.rb
+++ b/app/controllers/theme_controller.rb
@@ -23,7 +23,7 @@ class ThemeController < ApplicationController
   caches_page :show, if: Proc.new {|ctrl| ctrl.cache_css}
 
   def show
-    if stale?(@theme, file: @file)
+    if stale?(@theme, file: @file,  last_modified: css_last_modified)
       render :show, content_type: 'text/css', formats: [:css]
     end
   rescue Sass::SyntaxError => exc
@@ -50,6 +50,13 @@ class ThemeController < ApplicationController
     @theme.clear_cache(@file) unless self.cache_css
   end
 
+  def css_last_modified
+    @css_last_modified ||= [@theme.updated_at, css_updated_at].max
+  end
+  helper_method :css_last_modified
+
+  def css_updated_at
+    Dir.glob("app/stylesheets/**/*").map{|f| File.mtime(f)}.max
+  end
+
 end
-
-

--- a/app/stylesheets/ui/_wiki.scss
+++ b/app/stylesheets/ui/_wiki.scss
@@ -100,14 +100,12 @@ article {
     }
 
     ul, ol {
-      padding-left: 1em;
+      padding-left: 2.5em;
       margin-left: 0.5em;
     }
 
     ul {
       list-style: disc outside none;
-      padding-left: 1em;
-      margin-left: 0.5em;
       ul {
         list-style: circle outside none;
       }

--- a/app/views/theme/show.css.erb
+++ b/app/views/theme/show.css.erb
@@ -1,3 +1,3 @@
-<% cache([@theme.cache_key, @file]) do %>
+<% cache([@theme.name, css_last_modified, @file]) do %>
   <%= raw @theme.render_css(@file) %>
 <% end %>

--- a/config/directories.rb
+++ b/config/directories.rb
@@ -68,4 +68,3 @@ dirs.each do |dir|
     end
   end
 end
-


### PR DESCRIPTION
The padding was to small to display two digit numbered lists. Now we should be fine even for three digits.