### PR TITLE
alphabetic list of visible entities in sidebars

### DIFF
--- a/app/models/group_extension/users.rb
+++ b/app/models/group_extension/users.rb
@@ -53,7 +53,11 @@ module GroupExtension::Users
     end
 
     def with_admin(user)
-      where("groups.id IN (?)", user.admin_for_group_ids)
+      where(id: user.admin_for_group_ids)
+    end
+
+    def with_member(user)
+      where(id: user.all_group_ids)
     end
 
     def large

--- a/app/views/groups/_list_with_committees.html.haml
+++ b/app/views/groups/_list_with_committees.html.haml
@@ -1,0 +1,7 @@
+%ul.entities
+  - groups.each do |group|
+    %li= link_to_entity group,
+      avatar: current_theme.local_sidecolumn_icon_size,
+      class: group.parent_id ? 'indent' : ''
+  - if local_assigns[:more]
+    %li= link_to (:see_all_link.t + '&nbsp;&raquo;').html_safe, more

--- a/app/views/groups/structures/_show_in_sidebar.html.haml
+++ b/app/views/groups/structures/_show_in_sidebar.html.haml
@@ -5,14 +5,17 @@
 - if may_list_group_committees?
   - cache [current_language, @group.version_cache_key, :committees] do
     - if @group.real_committees.size > 0
-      = entity_list(@group.real_committees, header: :committees.t)
+      = entity_list @group.real_committees.order(:name),
+        header: :committees.t
       -# , after: link_line(create_committee_link))
     - if @group.has_a_council?
       = entity_list([@group.council], header: :council.t)
 - if @group.network? and may_list_memberships?
   - cache [current_language, @group.version_cache_key, :members] do
-    = entity_list(@group.groups, header: :member_groups_of_network.t)
+    = entity_list @group.groups.order(:name),
+      header: :member_groups_of_network.t
     -#after: link_line(:bullet, list_memberships_link, invite_link, requests_link))
 - if may_list_group_networks?
   - cache [current_language, @group.version_cache_key, :networks] do
-    = entity_list(@group.networks, header: :networks.t)
+    = entity_list @group.networks.order(:name),
+      header: :networks.t

--- a/app/views/me/notices/index.html.haml
+++ b/app/views/me/notices/index.html.haml
@@ -2,11 +2,9 @@
 - if groups.any?
   - content_for(:left_column) do
     %h2.space-ui-bottom.first=:groups.t
-    %ul.entities
-      - groups.each do |group|
-        - css_class = group.parent_id ? 'indent' : ''
-        %li= link_to_entity(group, avatar: current_theme.local_sidecolumn_icon_size, class: css_class)
-      %li= link_to((:see_all_link.t + '&nbsp;&raquo;').html_safe, groups_directory_path)
+    = render 'groups/list_with_committees',
+      groups: groups,
+        more: groups_directory_path
 
 %h2.space-ui-bottom.first
   = :notices.t

--- a/app/views/people/home/_friends.html.haml
+++ b/app/views/people/home/_friends.html.haml
@@ -1,7 +1,7 @@
-- cache [current_language, @user.version_cache_key] do
-  = entity_list(@user.friends.most_active(limit: 10),
+- cache [current_language, @user.version_cache_key, current_user.version_cache_key] do
+  %h3= :friends.t
+  = entity_list @user.friends.with_access(current_user => :view).most_active(limit: 10),
     {link_options: {avatar: 'small'},
-    header: content_tag(:b, :friends.t),
-    after: ''})
+    after: ''}
 
 

--- a/app/views/people/home/_groups.html.haml
+++ b/app/views/people/home/_groups.html.haml
@@ -1,6 +1,9 @@
+- cache [current_language, @user.version_cache_key, @current_user.version_cache_key] do
+  %h3= :shared_groups.t
+  = render 'groups/list_with_committees',
+    groups: @user.groups.with_member(current_user).recently_active
 - cache [current_language, @user.version_cache_key] do
-  = entity_list(@user.groups.recently_active(limit: 10),
-    {link_options: {avatar: 'small'},
-    header: content_tag(:b, :groups.t),
-    after: ''})
+  %h3= :public_groups.t
+  = render 'groups/list_with_committees',
+    groups: @user.groups.with_access(public: :view).recently_active
 

--- a/config/locales/en/groups.yml
+++ b/config/locales/en/groups.yml
@@ -51,6 +51,8 @@ en:
   ## MEMBERSHIP
   ##
 
+  shared_groups: "Shared Groups"
+  public_groups: "Public Groups"
   membership_requests: "Membership Requests"
   group_membership_count: "%{count} Members"
   membership_exists_error: "Membership already exists for %{member}"


### PR DESCRIPTION
Now we only display visible groups and users in the friends and group lists.
Also sorting groups by the ones one shares with the user in question and the
public ones.

Lists that can be sorted alphabetically in a meaningful way get sorted.