### PR TITLE
Fix picture upload issues, update crabgrass_media

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ gem 'uglify_html', :require => 'uglify_html',
 
 # media upload post processing has it's own repo
 # version is rather strict for now as api may still change.
-gem 'crabgrass_media', '~> 0.0.2', :require => 'media'
+gem 'crabgrass_media', '~> 0.0.5', :require => 'media'
 
 ##
 ## GEMS not required, but a really good idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,8 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     columnize (0.9.0)
-    crabgrass_media (0.0.2)
-      activesupport (~> 3.2)
+    crabgrass_media (0.0.5)
+      activesupport (>= 3.2)
     daemons (1.2.3)
     debugger (1.6.8)
       columnize (>= 0.3.1)
@@ -252,7 +252,7 @@ DEPENDENCIES
   cache_digests (~> 0.3)
   capybara
   coffee-rails (~> 3.2.2)
-  crabgrass_media (~> 0.0.2)
+  crabgrass_media (~> 0.0.5)
   daemons
   debugger
   delayed_job_active_record (~> 4.0)

--- a/app/models/picture/storage.rb
+++ b/app/models/picture/storage.rb
@@ -113,7 +113,7 @@ class Picture::Storage
   #
   #
   def file_name(geometry)
-    Picture::Geometry[geometry].to_s + ext
+    Picture::Geometry[geometry].to_s + '.' + ext
   end
 
 


### PR DESCRIPTION
* the file extension should be seperated by a .
* crabgrass_media 0.0.4 fixes a bug where ENOENT was raised
  after the conversion of a file failed.