### PR TITLE
debug: approving invites via email can result in 500

### DIFF
--- a/app/controllers/common/application/rescue_errors.rb
+++ b/app/controllers/common/application/rescue_errors.rb
@@ -233,9 +233,9 @@ module Common::Application::RescueErrors
   end
 
   def log_exception(exception)
-    Rails.logger.debug "Rescuing from #{exception.class}."
-    Rails.logger.debug exception.log_message if exception.respond_to? :log_message
-    Rails.logger.debug Rails.backtrace_cleaner.clean(exception.backtrace).join("\n")
+    Rails.logger.warn "Rescuing from #{exception.class}."
+    Rails.logger.warn exception.log_message if exception.respond_to? :log_message
+    Rails.logger.warn Rails.backtrace_cleaner.clean(exception.backtrace).join("\n")
   end
 
   #def flash_auth_error(mode)

--- a/test/helpers/integration/account_management.rb
+++ b/test/helpers/integration/account_management.rb
@@ -15,7 +15,7 @@ module AccountManagement
   def login(user = nil)
     # Create a user wihtout the lengthy signup procedure
     records[:user] ||= @user ||= user || FactoryGirl.create(:user)
-    visit '/' unless page.current_path == '/'
+    visit '/' unless page.current_path.present?
     fill_in :login_name.t, with: @user.login
     fill_in :login_password.t, with: @user.password || @user.login
     click_button :login_button.t

--- a/test/integration/group_invite_test.rb
+++ b/test/integration/group_invite_test.rb
@@ -2,7 +2,7 @@ require 'integration_test'
 
 class GroupInviteTest < IntegrationTest
 
-  def test_invited_via_email
+  def test_invite_new_via_email
     @group = groups(:animals)
     @request = RequestToJoinUsViaEmail.create created_by: users(:blue),
       email: 'sometest@email.test',
@@ -11,5 +11,18 @@ class GroupInviteTest < IntegrationTest
     signup
     click_on 'Approve'
     assert @group.memberships.where(user_id: @user).exists?
+    assert_content @group.display_name
+  end
+
+  def test_invite_existing_user_via_email
+    @group = groups(:animals)
+    @request = RequestToJoinUsViaEmail.create created_by: users(:blue),
+      email: 'sometest@email.test',
+      requestable: @group
+    visit "/me/requests/#{@request.id}?code=#{@request.code}"
+    login
+    click_on 'Approve'
+    assert @group.memberships.where(user_id: @user).exists?
+    assert_content @group.display_name
   end
 end


### PR DESCRIPTION
It looks like we only print the error messages for js errors in debug level.
Raising to warn.

Also added a test for accepting an invite that came via email as a user
who already has an account.