### PR TITLE
bugfix: sortable image list after file upload

### DIFF
--- a/app/views/pages/assets/create.js.rjs
+++ b/app/views/pages/assets/create.js.rjs
@@ -1,11 +1,17 @@
 page.replace 'page_sidebar', :partial => 'pages/sidebar/sidebar'
-page.replace_html 'assets_list', :partial => '/common/assets/asset_as_li', :collection => @page.assets
+page.replace_html 'assets_list',
+  partial: '/common/assets/asset_as_li',
+  collection: @page.respond_to?(:images) ? @page.images : @page.assets
 page << 'initAjaxUpload();'
 
 page << <<-EOJS
 if (document.getElementById('MB_window')) { Modalbox.updatePosition(); }
 var list = document.getElementById('assets_list');
 if (list.classList.contains('sortable')) {
-  #{sortable_element_js( "assets_list", :constraint => false, :overlap => :horizontal, :url => page_url(@page, :action => :update) )}
+  #{sortable_element_js "assets_list",
+      constraint: false,
+      overlap: :horizontal,
+      url: sort_images_url(page_id: @page)
+   }
 }
 EOJS

--- a/test/integration/page_creation_test.rb
+++ b/test/integration/page_creation_test.rb
@@ -10,9 +10,6 @@ class PageCreationTest < JavascriptIntegrationTest
     # hidden users do not show up in autocomplete
     add_recipients hidden_user, blocking_user
     click_on :create.t
-
-    assert_content public_user.display_name
-    assert_no_content blocking_user.display_name
     assert_page_users user, public_user, hidden_user
   end
 
@@ -43,7 +40,7 @@ class PageCreationTest < JavascriptIntegrationTest
     assert_no_content public_group.display_name
     assert_page_users user
   end
-  
+
   def test_add_tags
     login users(:red)
     prepare_page :discussion_page


### PR DESCRIPTION
The url for the sortable_element was wrong. It would also render the collection of images in a wrong order.

We now work around the latter by using @page.images if it's available
(gallery) rather than @page.assets (other page types). images are sorted
by position based on showing wheras assets are not sorted right now.

The longer term fix for this will be to add a position field to the
assets and remove the showings table all together (we don't allow
reusing images across galeries for a long time now.)