### PR TITLE
bugfix: fix committee creation - ensure parent

### DIFF
--- a/app/controllers/groups/structures_controller.rb
+++ b/app/controllers/groups/structures_controller.rb
@@ -18,7 +18,7 @@ class Groups::StructuresController < Groups::SettingsController
     else
       raise_denied unless may_create_council?
     end
-    @committee = group_class.create group_params
+    @committee = group_class.new group_params
     @group.add_committee!(@committee)
     @committee.add_user!(current_user) if @committee.council?
     success :group_successfully_created.t

--- a/test/functional/groups/structures_controller_test.rb
+++ b/test/functional/groups/structures_controller_test.rb
@@ -47,6 +47,19 @@ class Groups::StructuresControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  # the same group can have only one committee with the same name.
+  def test_create_no_duplicates
+    login_as users(:blue)
+    assert_permission :may_edit_group_structure? do
+      assert_no_difference 'Committee.count' do
+        get :create,
+          group_id: groups(:rainbow),
+          type: 'committee',
+          group: committee_attributes(name: 'the-warm-colors')
+      end
+    end
+  end
+
   def test_new_council
     login_as @user
     assert_permission :may_edit_group_structure? do


### PR DESCRIPTION
We used to create the committee before adding it to the parent.
So if a naming conflict turned up we already had created the record.

Now we just build the committee and it will be saved in
  Group#add_committee!
for the first time.