### PR TITLE
only create a symlink for public asset dirs if needed

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -40,15 +40,12 @@ class AssetsController < ApplicationController
 
   # Update access and redirect to the same path - which will now have a
   # symlink in public
-  # This only applies iff asset is public AND the public file is not in place.
   def symlink_public_asset
-    return unless @asset.public? and !File.exist?(@asset.public_filename)
-    @asset.update_access
-    @asset.generate_thumbnails
-    raise_not_found(:file.t) unless @asset.thumbnails.any?
-
-    # redirect to the same url again, but next time they will get the symlinks
-    redirect_to
+    if @asset.symlink_missing?
+      @asset.update_access
+      # redirect to the same url again, but next time they will get the symlinks
+      redirect_to
+    end
   end
 
   ## Helper Methods

--- a/app/models/asset_extension/storage.rb
+++ b/app/models/asset_extension/storage.rb
@@ -217,9 +217,18 @@ module AssetExtension # :nodoc:
       File.file?(private_filename) ? File.read(private_filename) : nil
     end
 
+    def symlink_missing?
+      self.public? and !has_symlink?
+    end
+    public :symlink_missing?
+
+    def has_symlink?
+      File.exist?(File.dirname(public_filename))
+    end
+
     # creates a symlink from the private asset storage to a publicly accessible directory
     def add_symlink
-      unless File.exist?(File.dirname(public_filename))
+      unless has_symlink?
         real_private_path = Pathname.new(private_filename).realpath.dirname
         real_public_path  = Pathname.new(public_storage).realpath
         public_to_private = real_private_path.relative_path_from(real_public_path)
@@ -231,7 +240,7 @@ module AssetExtension # :nodoc:
 
     # removes symlink from public directory
     def remove_symlink
-      if File.exist?(File.dirname(public_filename))
+      if has_symlink?
         FileUtils.rm(File.dirname(public_filename))
       end
     end


### PR DESCRIPTION
Before we tested for the existance of the file and tried to symlink the
directory if it did not exist. Then we would redirect to the same url
assuming this fixed things.

Turns out that if there is a different issue such as the file missing -
not the symlink to the dir this does not fix thigns but leads to endless
redirects.

So now we only attempt to fix things by symlinking if there was no symlink
yet.