### PR TITLE
bugfix: fix page updates mailer, i18n keys

### DIFF
--- a/app/models/mailer/page_histories.rb
+++ b/app/models/mailer/page_histories.rb
@@ -57,9 +57,9 @@ class Mailer::PageHistories < ActionMailer::Base
 
   # add some defaults
   def mail(options = {})
-    return if @histories.blank?
+    return if @histories.blank? || @recipient.email.blank?
     @histories = @histories.group_by(&:page).to_a
-    super options.reverse_merge from: sender, to: @recipient
+    super options.reverse_merge from: sender, to: @recipient.email
   end
 
   def self.digest_recipients
@@ -92,11 +92,11 @@ class Mailer::PageHistories < ActionMailer::Base
   end
 
   def digest_subject
-    I18n.t("mail.subject.daily_digest", site: @site.title)
+    I18n.t("mailer.page_histories.daily_digest", site: @site.title)
   end
 
   def update_subject
-    I18n.t("mail.subject.daily_digest", site: @site.title)
+    I18n.t("mailer.page_histories.page_update", site: @site.title)
   end
 
   def sender

--- a/app/models/page_history.rb
+++ b/app/models/page_history.rb
@@ -11,15 +11,14 @@ class PageHistory < ActiveRecord::Base
 
   def send_single_notification
     return if self.reload.notification_sent?
-    Mailer::PageHistory.deliver_updates_for page,
+    Mailer::PageHistories.deliver_updates_for page,
       to: recipients_for_single_notification
   end
 
-  handle_asynchronously :send_single_notification
-
-  # TODO: Let's wait 30 minutes so notifications for all changes to the same page
+  # Let's wait 30 minutes so notifications for all changes to the same page
   # within that timeframe can be combined.
-  #   run_at: Proc.new { 30.minutes.from_now }
+  handle_asynchronously :send_single_notification,
+    run_at: Proc.new { 30.minutes.from_now }
 
   def single_notification_wanted?
     recipients_for_single_notification.present?

--- a/app/views/mailer/page_histories/_page.text.erb
+++ b/app/views/mailer/page_histories/_page.text.erb
@@ -1,6 +1,6 @@
 <%- page, histories = page if page.is_a? Array%>
 <%- histories.sort_by!(&:created_at) %>
-<%= I18n.t "mailer.page_history.the_page_you_are_watching_description", :page_title => page.title %>:
+<%= I18n.t "mailer.page_histories.the_page_you_are_watching_description", :page_title => page.title %>:
   <%= URI::encode context_page_url(page.owner.name, page.name_url) %>
 
 <%= render histories %>

--- a/app/views/mailer/page_histories/_paranoid.text.erb
+++ b/app/views/mailer/page_histories/_paranoid.text.erb
@@ -1,8 +1,7 @@
-<%= I18n.t("mailer.page_history.pages_you_are_watching_have_been_modified", count: count) %>
+<%= I18n.t("mailer.page_histories.pages_you_are_watching_have_been_modified", count: count) %>
 
-<%= I18n.t("mailer.page_history.we_do_not_include_details") %>
+<%= I18n.t("mailer.page_histories.we_leave_out_details") %>
+<%-# I18n.t("mailer.page_histories.upload_your_public_pgp_key") %>
 
-<%= I18n.t("mailer.page_history.you_can_find_updates_here") %>
+<%= I18n.t("mailer.page_histories.you_can_find_updates_here") %>
   <%= URI::encode "http://#{@site.domain}/me" %>
-
-

--- a/app/views/mailer/page_histories/digest.text.erb
+++ b/app/views/mailer/page_histories/digest.text.erb
@@ -8,7 +8,7 @@
 
 ------------
 
-<%= I18n.t("mailer.page_history.change_your_settings_here", :page_link => me_settings_url(:host => @site.domain)) %>
-<%= I18n.t("mailer.page_history.you_can_turn_of_or_configure_notifications") %>.
+<%= I18n.t("mailer.page_histories.change_your_settings_here", :page_link => me_settings_url(:host => @site.domain)) %>
+<%= I18n.t("mailer.page_histories.you_can_turn_of_or_configure_notifications") %>.
 
 ------------

--- a/config/locales/en/emails.yml
+++ b/config/locales/en/emails.yml
@@ -1,12 +1,14 @@
 en:
   mailer:
     hello: "Hello %{user_name}"
-    page_history:
-      a_page_has_been_modified: "%{site_title} : A page has been modified"
+    page_histories:
+      page_update: "%{site} : A page has been modified"
+      daily_digest: "%{site} : Daily summary of page modifications"
       pages_you_are_watching_have_been_modified:
         one:   "A page that you are watching has been modified since the last notification."
         other: "%{count} pages that you are watching have been modified since the last notification."
       we_leave_out_details: "We leave out the details in this email to protect information you might want to keep private."
+      upload_your_public_pgp_key: "To receive more detailed updates in encrypted emailsplease upload your public pgp key."
       you_can_find_updates_here: "You will find more details and a list of recently changed pages here:"
       the_page_you_are_watching_description: "The page you are watching \"%{page_title}\" has been modified"
       change_your_settings_here: "Change your email notification settings here: %{page_link}"


### PR DESCRIPTION
The mailer is called Mailer::PageHistories so it does not interfere
with the PageHistory toplevel class.

Also... a number of i18n keys were messed up.