### PR TITLE
bugfix: remove caching of page entities

### DIFF
--- a/app/views/groups/structures/_show_in_sidebar.html.haml
+++ b/app/views/groups/structures/_show_in_sidebar.html.haml
@@ -3,19 +3,16 @@
 -# otherwise we are caching stuff for people who shouldn't see it.
 -#
 - if may_list_group_committees?
-  - cache [current_language, @group.version_cache_key, :committees] do
-    - if @group.real_committees.size > 0
-      = entity_list @group.real_committees.order(:name),
-        header: :committees.t
-      -# , after: link_line(create_committee_link))
-    - if @group.has_a_council?
-      = entity_list([@group.council], header: :council.t)
+  - if @group.real_committees.size > 0
+    = entity_list @group.real_committees.order(:name),
+      header: :committees.t
+    -# , after: link_line(create_committee_link))
+  - if @group.has_a_council?
+    = entity_list([@group.council], header: :council.t)
 - if @group.network? and may_list_memberships?
-  - cache [current_language, @group.version_cache_key, :members] do
-    = entity_list @group.groups.order(:name),
-      header: :member_groups_of_network.t
-    -#after: link_line(:bullet, list_memberships_link, invite_link, requests_link))
+  = entity_list @group.groups.order(:name),
+    header: :member_groups_of_network.t
+  -#after: link_line(:bullet, list_memberships_link, invite_link, requests_link))
 - if may_list_group_networks?
-  - cache [current_language, @group.version_cache_key, :networks] do
-    = entity_list @group.networks.order(:name),
-      header: :networks.t
+  = entity_list @group.networks.order(:name),
+    header: :networks.t


### PR DESCRIPTION
We would also have to expire the cache every time a link or a name changes.
This boils down to
  cache @group, @group.committees.count, @group.committees.max(:updated_at), ... do
Currently rendering the corresponding lists is not really slow - 20 ms. for all the
entities of animals.

So if we have to query every association for it's size and the max updated at
we probably won't gain much and this kind of caching is error prone.